### PR TITLE
Add install-noconfig make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ install:
 	mv -f  $(DESTDIR)$(BINDIR)/$(NAME)  $(DESTDIR)$(SBINDIR)/$(NAME)
 	ln -snf  $(SBINDIR)/$(NAME)  $(DESTDIR)$(SBINDIR)/configure-osg
 
+install-noconfig:
+	python setup.py install_lib install_scripts
+	mkdir -p  $(DESTDIR)$(SBINDIR)
+	mv -f  $(DESTDIR)$(BINDIR)/$(NAME)  $(DESTDIR)$(SBINDIR)/$(NAME)
+	ln -snf  $(SBINDIR)/$(NAME)  $(DESTDIR)$(SBINDIR)/configure-osg
+
 install-3.1:
 	@echo "OSG 3.1 is unsupported."
 	@exit 1
@@ -24,4 +30,4 @@ install-3.2: install
 
 install-3.3: install
 
-.PHONY: _default  install  install-3.1  install-3.2  install-3.3
+.PHONY: _default  install  install-3.1  install-3.2  install-3.3 install-noconfig


### PR DESCRIPTION
This installs just the script and python libraries, but does not
overwrite existing configs.  Useful for testing.