### PR TITLE
Catch os.path.samefile error if ssh_key_loc doesn't exist

### DIFF
--- a/osg_configure/configure_modules/bosco.py
+++ b/osg_configure/configure_modules/bosco.py
@@ -212,12 +212,12 @@ class BoscoConfiguration(JobManagerConfiguration):
         except OSError as err:
             if err.errno != errno.EEXIST:
                 raise
-        if not os.path.samefile(ssh_key, ssh_key_loc):
-            try:
+        try:
+            if not os.path.exists(ssh_key_loc) or not os.path.samefile(ssh_key, ssh_key_loc):
                 shutil.copy(ssh_key, ssh_key_loc)
-            except OSError as err:
-                self.log("Error copying SSH key to %s: %s" % (ssh_key_loc, err), level=logging.ERROR)
-                return False
+        except OSError as err:
+            self.log("Error copying SSH key to %s: %s" % (ssh_key_loc, err), level=logging.ERROR)
+            return False
 
         os.chmod(ssh_key_loc, stat.S_IRUSR | stat.S_IWUSR)
 


### PR DESCRIPTION
os.path.samefile raises an OSError if either of the files doesn't exist.
Don't raise an error if the dest file doesn't exist. Do raise an error
if the source file doesn't exist. (SOFTWARE-2188)