### PR TITLE
Add required cpu_platform to example

### DIFF
--- a/config/30-gip.ini
+++ b/config/30-gip.ini
@@ -124,6 +124,7 @@ advertise_gums = FALSE
 ; outbound_network = TRUE
 ; allowed_vos = osg, cms
 ; max_wall_time = 1440
+; cpu_platform = x86_64
 
 
 ;===================================================================


### PR DESCRIPTION
Add the required attribute `cpu_platform` to the subcluster example from UNL.