### PR TITLE
Improve GIP tests

### DIFF
--- a/osg_configure/configure_modules/gip.py
+++ b/osg_configure/configure_modules/gip.py
@@ -137,18 +137,7 @@ class GipConfiguration(BaseConfiguration):
                 raise exceptions.SettingError(msg)
 
         if utilities.ce_installed():
-            # All CEs must advertise subclusters
-            has_sc = self.check_subclusters(configuration)
-            if not has_sc:
-                try:
-                    self._check_entry(configuration, "GIP", "sc_number", REQUIRED,
-                                      POSITIVE_INT)
-                except (TypeError, ValueError, exceptions.SettingError):
-                    msg = "There is no `subcluster` section and the old-style subcluster" + \
-                          "setup in GIP is not configured. " + \
-                          " Please see the configuration documentation."
-                    raise exceptions.SettingError(msg)
-
+            self._parse_configuration_ce(configuration)
 
         # Check for the presence of the classic SE
         has_classic_se = True
@@ -185,6 +174,19 @@ class GipConfiguration(BaseConfiguration):
                          level=logging.ERROR)
                 raise exceptions.SettingError(err_msg)
             self.gip_user = username
+
+    def _parse_configuration_ce(self, configuration):
+        # All CEs must advertise subclusters
+        has_sc = self.check_subclusters(configuration)
+        if not has_sc:
+            try:
+                self._check_entry(configuration, "GIP", "sc_number", REQUIRED,
+                                  POSITIVE_INT)
+            except (TypeError, ValueError, exceptions.SettingError):
+                msg = "There is no `subcluster` section and the old-style subcluster" + \
+                      "setup in GIP is not configured. " + \
+                      " Please see the configuration documentation."
+                raise exceptions.SettingError(msg)
 
     check_sc = staticmethod(subcluster.check_section)
 

--- a/tests/test_gip.py
+++ b/tests/test_gip.py
@@ -200,6 +200,7 @@ class TestGip(unittest.TestCase):
         config_parser.read(config_file)
         gip_config = gip.GipConfiguration(logger=global_logger)
         gip_config._parse_configuration(config_parser)
+        gip_config._parse_configuration_ce(config_parser)
 
     def test_doherty(self):
         """
@@ -210,6 +211,7 @@ class TestGip(unittest.TestCase):
         config_parser.read(config_file)
         gip_config = gip.GipConfiguration(logger=global_logger)
         gip_config._parse_configuration(config_parser)
+        gip_config._parse_configuration_ce(config_parser)
 
     def test_local_settings(self):
         """
@@ -252,6 +254,7 @@ class TestGip(unittest.TestCase):
                           get_test_config(SAMPLE_VO_MAP_LOCATION))
         gip_config = gip.GipConfiguration(logger=global_logger)
         gip_config._parse_configuration(config_parser)
+        gip_config._parse_configuration_ce(config_parser)
 
     def test_allowed_jobmanagers(self):
         """
@@ -265,6 +268,7 @@ class TestGip(unittest.TestCase):
                           get_test_config(SAMPLE_VO_MAP_LOCATION))
         gip_config = gip.GipConfiguration(logger=global_logger)
         gip_config._parse_configuration(config_parser)
+        gip_config._parse_configuration_ce(config_parser)
 
         config_parser = ConfigParser.SafeConfigParser()
         config_file = get_test_config("gip/allowed_jobmanager2.ini")
@@ -274,6 +278,7 @@ class TestGip(unittest.TestCase):
                           get_test_config(SAMPLE_VO_MAP_LOCATION))
         gip_config = gip.GipConfiguration(logger=global_logger)
         gip_config._parse_configuration(config_parser)
+        gip_config._parse_configuration_ce(config_parser)
 
         config_parser = ConfigParser.SafeConfigParser()
         config_file = get_test_config("gip/allowed_jobmanager3.ini")
@@ -283,6 +288,7 @@ class TestGip(unittest.TestCase):
                           get_test_config(SAMPLE_VO_MAP_LOCATION))
         gip_config = gip.GipConfiguration(logger=global_logger)
         gip_config._parse_configuration(config_parser)
+        gip_config._parse_configuration_ce(config_parser)
 
         config_parser = ConfigParser.SafeConfigParser()
         config_file = get_test_config("gip/allowed_jobmanager4.ini")
@@ -292,6 +298,7 @@ class TestGip(unittest.TestCase):
                           get_test_config(SAMPLE_VO_MAP_LOCATION))
         gip_config = gip.GipConfiguration(logger=global_logger)
         gip_config._parse_configuration(config_parser)
+        gip_config._parse_configuration_ce(config_parser)
 
         config_parser = ConfigParser.SafeConfigParser()
         config_file = get_test_config("gip/allowed_jobmanager5.ini")
@@ -301,6 +308,7 @@ class TestGip(unittest.TestCase):
                           get_test_config(SAMPLE_VO_MAP_LOCATION))
         gip_config = gip.GipConfiguration(logger=global_logger)
         gip_config._parse_configuration(config_parser)
+        gip_config._parse_configuration_ce(config_parser)
 
         config_parser = ConfigParser.SafeConfigParser()
         config_file = get_test_config("gip/allowed_jobmanager6.ini")
@@ -310,6 +318,7 @@ class TestGip(unittest.TestCase):
                           get_test_config(SAMPLE_VO_MAP_LOCATION))
         gip_config = gip.GipConfiguration(logger=global_logger)
         gip_config._parse_configuration(config_parser)
+        gip_config._parse_configuration_ce(config_parser)
 
         config_parser = ConfigParser.SafeConfigParser()
         config_file = get_test_config("gip/invalid_jobmanager1.ini")

--- a/tests/test_gip.py
+++ b/tests/test_gip.py
@@ -49,6 +49,7 @@ class TestGip(unittest.TestCase):
             config_parser.read(config_file)
             gip_config = gip.GipConfiguration(logger=global_logger)
             gip_config._parse_configuration(config_parser)
+            gip_config._parse_configuration_ce(config_parser)
         except exceptions.SettingError:
             did_fail = True
         self.assertTrue(did_fail, msg="Did not properly detect a missing SC.")
@@ -143,6 +144,7 @@ class TestGip(unittest.TestCase):
             config_parser.read(config_file)
             gip_config = gip.GipConfiguration(logger=global_logger)
             gip_config._parse_configuration(config_parser)
+            gip_config._parse_configuration_ce(config_parser)
         except exceptions.SettingError:
             did_fail = True
         self.assertTrue(did_fail, msg="Did not detect enabled CHANGEME section.")
@@ -174,6 +176,7 @@ class TestGip(unittest.TestCase):
             config_parser.read(config_file)
             gip_config = gip.GipConfiguration(logger=global_logger)
             gip_config._parse_configuration(config_parser)
+            gip_config._parse_configuration_ce(config_parser)
         except exceptions.SettingError:
             did_fail = True
         self.assertTrue(did_fail, msg="Did not properly detect missing attrs.")


### PR DESCRIPTION
The GIP unit tests do not properly test some functionality if one of the `osg-ce` RPMs isn't installed, leading to bogus errors in the test suite. Fix that.