### PR TITLE
Relax checks on non-site-controlled hosts

### DIFF
--- a/osg_configure/configure_modules/gratia.py
+++ b/osg_configure/configure_modules/gratia.py
@@ -414,11 +414,15 @@ in your config.ini file."""
                 sys.stdout.write(self.metric_probe_deprecation + "\n")
                 self.log(self.metric_probe_deprecation, level=logging.WARNING)
             server = self.enabled_probe_settings[probe].split(':')[0]
-            if not validation.valid_domain(server, True):
-                err_mesg = "The server specified for probe %s does not " % probe
-                err_mesg += "resolve: %s" % server
+            if not validation.valid_domain(server, False):
+                err_mesg = "The server specified for probe %s is not " % probe
+                err_mesg += "a valid domain: %s" % server
                 self.log(err_mesg, level=logging.ERROR)
                 valid = False
+            elif not validation.valid_domain(server, True):
+                err_mesg = "The server specified for probe %s does not " % probe
+                err_mesg += "resolve: %s" % server
+                self.log(err_mesg, level=logging.WARNING)
             if server != self.enabled_probe_settings[probe]:
                 port = self.enabled_probe_settings[probe].split(':')[1]
                 try:

--- a/tests/test_gratia.py
+++ b/tests/test_gratia.py
@@ -235,26 +235,6 @@ class TestGratia(unittest.TestCase):
                          0,
                          "Disabled configuration should have no attributes")
 
-    def testInvalidProbes1(self):
-        """
-        Test the check_attributes function to see if it catches invalid
-        probes
-        """
-
-        config_file = get_test_config("gratia/invalid_probe1.ini")
-        configuration = ConfigParser.SafeConfigParser()
-        configuration.read(config_file)
-
-        settings = gratia.GratiaConfiguration(logger=global_logger)
-        try:
-            settings.parse_configuration(configuration)
-        except Exception, e:
-            self.fail("Received exception while parsing configuration: %s" % e)
-
-        attributes = settings.get_attributes()
-        self.assertFalse(settings.check_attributes(attributes),
-                         "Did not notice invalid probe specification")
-
     def testInvalidProbes2(self):
         """
         Test the check_attributes function to see if it catches invalid


### PR DESCRIPTION
The absence of sites that are not controlled by the admin should not cause osg-configure to error out. (SOFTWARE-2123)