### PR TITLE
Edit authorized_only section of lcmaps.db

### DIFF
--- a/osg_configure/configure_modules/misc.py
+++ b/osg_configure/configure_modules/misc.py
@@ -234,7 +234,7 @@ configuration:
         # Update GUMS endpoint (if using GUMS)
         #
         if gums:
-            endpoint_re = re.compile(r'^\s*"--endpoint\s+https://.*/gums/services.*"\s*$',
+            endpoint_re = re.compile(r'^\s*"--endpoint\s+https://.*/gums/services.*"\s*?$',
                                      re.MULTILINE)
             replacement = "             \"--endpoint https://%s:8443" % (gums_host)
             replacement += "/gums/services/GUMSXACMLAuthorizationServicePort\""

--- a/osg_configure/configure_modules/misc.py
+++ b/osg_configure/configure_modules/misc.py
@@ -202,38 +202,32 @@ class MiscConfiguration(BaseConfiguration):
         """
         Update lcmaps file and give appropriate messages if lcmaps.db.rpmnew exists
         """
-
-        self.log("Updating " + LCMAPS_DB_LOCATION, level=logging.INFO)
-        lcmaps_db = open(LCMAPS_DB_LOCATION).read()
-        endpoint_re = re.compile(r'^\s*"--endpoint\s+https://.*/gums/services.*"\s*$',
-                                 re.MULTILINE)
-        replacement = "             \"--endpoint https://%s:8443" % (self.options['gums_host'].value)
-        replacement += "/gums/services/GUMSXACMLAuthorizationServicePort\""
-        lcmaps_db = endpoint_re.sub(replacement, lcmaps_db)
-        utilities.atomic_write(LCMAPS_DB_LOCATION, lcmaps_db)
-
-        rpmnew_file = LCMAPS_DB_LOCATION + ".rpmnew"
         warning_message = """It appears that you've updated the lcmaps RPM and the
-configuration has changed. 
-If you have ever edited /etc/lcmaps.db by hand (most people don't), then you 
+configuration has changed.
+If you have ever edited /etc/lcmaps.db by hand (most people don't), then you
 should:
    1. Edit /etc/lcmaps.db.rpmnew to make your changes again
    2. mv /etc/lcmaps.db.rpmnew /etc/lcmaps.db
-If you haven't edited /etc/lcmaps.db by hand, then you can just use the new 
+If you haven't edited /etc/lcmaps.db by hand, then you can just use the new
 configuration:
    1. mv /etc/lcmaps.db.rpmnew /etc/lcmaps.db"""
+
+        files_to_update = [LCMAPS_DB_LOCATION]
+        rpmnew_file = LCMAPS_DB_LOCATION + ".rpmnew"
         if validation.valid_file(rpmnew_file):
             self.log(warning_message, level=logging.WARNING)
-        else:
-            return
+            files_to_update.append(rpmnew_file)
 
-        lcmaps_db = open(rpmnew_file).read()
-        endpoint_re = re.compile(r'^\s*"--endpoint\s+https://.*/gums/services.*"\s*$',
-                                 re.MULTILINE)
-        replacement = "             \"--endpoint https://%s:8443" % (self.options['gums_host'].value)
-        replacement += "/gums/services/GUMSXACMLAuthorizationServicePort\""
-        lcmaps_db = endpoint_re.sub(replacement, lcmaps_db)
-        utilities.atomic_write(rpmnew_file, lcmaps_db)
+        for lcmaps_db_file in files_to_update:
+            self.log("Updating " + lcmaps_db_file, level=logging.INFO)
+            lcmaps_db = open(lcmaps_db_file).read()
+            endpoint_re = re.compile(r'^\s*"--endpoint\s+https://.*/gums/services.*"\s*$',
+                                     re.MULTILINE)
+            replacement = "             \"--endpoint https://%s:8443" % (self.options['gums_host'].value)
+            replacement += "/gums/services/GUMSXACMLAuthorizationServicePort\""
+            lcmaps_db = endpoint_re.sub(replacement, lcmaps_db)
+            utilities.atomic_write(lcmaps_db_file, lcmaps_db)
+
 
     def _disable_callout(self):
         """

--- a/tests/configs/misc/lcmaps.db.fresh
+++ b/tests/configs/misc/lcmaps.db.fresh
@@ -1,0 +1,38 @@
+gumsclient = "lcmaps_gums_client.mod"
+             "-resourcetype ce"
+             "-actiontype execute-now"
+             "-capath /etc/grid-security/certificates"
+             "-cert   /etc/grid-security/hostcert.pem"
+             "-key    /etc/grid-security/hostkey.pem"
+             "--cert-owner root"
+             "--endpoint https://gums.fnal.gov:8443/gums/services/GUMSXACMLAuthorizationServicePort"
+
+gridmapfile = "lcmaps_localaccount.mod"
+              "-gridmap /etc/grid-security/grid-mapfile"
+
+verifyproxy = "lcmaps_verify_proxy.mod"
+          "--allow-limited-proxy"
+          " -certdir /etc/grid-security/certificates"
+
+good        = "lcmaps_dummy_good.mod"
+bad         = "lcmaps_dummy_bad.mod"
+
+
+authorize_only:
+
+## Policy 1: GUMS (most common, default)
+gumsclient -> good | bad
+
+## Policy 2: grid-mapfile
+#gridmapfile -> good | bad
+
+
+glexec:
+
+## Policy 1: GUMS (most common)
+#verifyproxy -> gumsclient
+#gumsclient -> glexectracking
+
+## Policy 2: grid-mapfile
+#verifyproxy -> gridmapfile
+#gridmapfile -> glexectracking

--- a/tests/configs/misc/lcmaps.db.gridmap1
+++ b/tests/configs/misc/lcmaps.db.gridmap1
@@ -1,0 +1,38 @@
+gumsclient = "lcmaps_gums_client.mod"
+             "-resourcetype ce"
+             "-actiontype execute-now"
+             "-capath /etc/grid-security/certificates"
+             "-cert   /etc/grid-security/hostcert.pem"
+             "-key    /etc/grid-security/hostkey.pem"
+             "--cert-owner root"
+             "--endpoint https://gums.fnal.gov:8443/gums/services/GUMSXACMLAuthorizationServicePort"
+
+gridmapfile = "lcmaps_localaccount.mod"
+              "-gridmap /etc/grid-security/grid-mapfile"
+
+verifyproxy = "lcmaps_verify_proxy.mod"
+          "--allow-limited-proxy"
+          " -certdir /etc/grid-security/certificates"
+
+good        = "lcmaps_dummy_good.mod"
+bad         = "lcmaps_dummy_bad.mod"
+
+
+authorize_only:
+
+## Policy 1: GUMS (most common, default)
+#gumsclient -> good | bad
+
+## Policy 2: grid-mapfile
+gridmapfile -> good | bad
+
+
+glexec:
+
+## Policy 1: GUMS (most common)
+#verifyproxy -> gumsclient
+#gumsclient -> glexectracking
+
+## Policy 2: grid-mapfile
+#verifyproxy -> gridmapfile
+#gridmapfile -> glexectracking

--- a/tests/configs/misc/lcmaps.db.gridmap2
+++ b/tests/configs/misc/lcmaps.db.gridmap2
@@ -1,0 +1,38 @@
+gumsclient = "lcmaps_gums_client.mod"
+             "-resourcetype ce"
+             "-actiontype execute-now"
+             "-capath /etc/grid-security/certificates"
+             "-cert   /etc/grid-security/hostcert.pem"
+             "-key    /etc/grid-security/hostkey.pem"
+             "--cert-owner root"
+             "--endpoint https://testnode.testdomain:8443/gums/services/GUMSXACMLAuthorizationServicePort"
+
+gridmapfile = "lcmaps_localaccount.mod"
+              "-gridmap /etc/grid-security/grid-mapfile"
+
+verifyproxy = "lcmaps_verify_proxy.mod"
+          "--allow-limited-proxy"
+          " -certdir /etc/grid-security/certificates"
+
+good        = "lcmaps_dummy_good.mod"
+bad         = "lcmaps_dummy_bad.mod"
+
+
+authorize_only:
+
+## Policy 1: GUMS (most common, default)
+#gumsclient -> good | bad
+
+## Policy 2: grid-mapfile
+gridmapfile -> good | bad
+
+
+glexec:
+
+## Policy 1: GUMS (most common)
+#verifyproxy -> gumsclient
+#gumsclient -> glexectracking
+
+## Policy 2: grid-mapfile
+#verifyproxy -> gridmapfile
+#gridmapfile -> glexectracking

--- a/tests/configs/misc/lcmaps.db.gums
+++ b/tests/configs/misc/lcmaps.db.gums
@@ -1,0 +1,38 @@
+gumsclient = "lcmaps_gums_client.mod"
+             "-resourcetype ce"
+             "-actiontype execute-now"
+             "-capath /etc/grid-security/certificates"
+             "-cert   /etc/grid-security/hostcert.pem"
+             "-key    /etc/grid-security/hostkey.pem"
+             "--cert-owner root"
+             "--endpoint https://testnode.testdomain:8443/gums/services/GUMSXACMLAuthorizationServicePort"
+
+gridmapfile = "lcmaps_localaccount.mod"
+              "-gridmap /etc/grid-security/grid-mapfile"
+
+verifyproxy = "lcmaps_verify_proxy.mod"
+          "--allow-limited-proxy"
+          " -certdir /etc/grid-security/certificates"
+
+good        = "lcmaps_dummy_good.mod"
+bad         = "lcmaps_dummy_bad.mod"
+
+
+authorize_only:
+
+## Policy 1: GUMS (most common, default)
+gumsclient -> good | bad
+
+## Policy 2: grid-mapfile
+#gridmapfile -> good | bad
+
+
+glexec:
+
+## Policy 1: GUMS (most common)
+#verifyproxy -> gumsclient
+#gumsclient -> glexectracking
+
+## Policy 2: grid-mapfile
+#verifyproxy -> gridmapfile
+#gridmapfile -> glexectracking

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -333,6 +333,58 @@ class TestMisc(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
 
+    def testLCMAPSGums(self):
+        """
+        Test to make sure lcmaps.db is properly modified for using GUMS
+        """
+        lcmaps_pre = open(get_test_config('misc/lcmaps.db.fresh')).read()
+        expected_lcmaps_post = open(get_test_config('misc/lcmaps.db.gums')).read()
+
+        lcmaps_post = misc.MiscConfiguration._update_lcmaps_text(lcmaps_pre, True, "testnode.testdomain")
+
+        self.assertEqual(lcmaps_post, expected_lcmaps_post,
+                         "lcmaps.db incorrectly updated for GUMS")
+
+    def testLCMAPSFreshGridmap(self):
+        """
+        Test to make sure a fresh lcmaps.db is properly modified for using a
+        grid-mapfile.
+        """
+        lcmaps_pre = open(get_test_config('misc/lcmaps.db.fresh')).read()
+        expected_lcmaps_post = open(get_test_config('misc/lcmaps.db.gridmap1')).read()
+
+        lcmaps_post = misc.MiscConfiguration._update_lcmaps_text(lcmaps_pre, False, "testnode.testdomain")
+
+        self.assertEqual(lcmaps_post, expected_lcmaps_post,
+                         "Fresh lcmaps.db incorrectly updated for grid-mapfile")
+
+    def testLCMAPSModifiedGridmap(self):
+        """
+        Test to make sure a modified lcmaps.db is properly further modified
+        for using a grid-mapfile.
+        """
+        lcmaps_pre = open(get_test_config('misc/lcmaps.db.gums')).read()
+        expected_lcmaps_post = open(get_test_config('misc/lcmaps.db.gridmap2')).read()
+
+        lcmaps_post = misc.MiscConfiguration._update_lcmaps_text(lcmaps_pre, False, "localhost")
+
+        self.assertEqual(lcmaps_post, expected_lcmaps_post,
+                         "Modified lcmaps.db incorrectly updated for grid-mapfile")
+
+    def testLCMAPSModifiedGUMS(self):
+        """
+        Test to make sure a modified lcmaps.db is properly further modified
+        for using GUMS.
+        """
+        lcmaps_pre = open(get_test_config('misc/lcmaps.db.gridmap1')).read()
+        expected_lcmaps_post = open(get_test_config('misc/lcmaps.db.gums')).read()
+
+        lcmaps_post = misc.MiscConfiguration._update_lcmaps_text(lcmaps_pre, True, "testnode.testdomain")
+
+        self.assertEqual(lcmaps_post, expected_lcmaps_post,
+                         "Modified lcmaps.db incorrectly updated for GUMS")
+
+
 if __name__ == '__main__':
     console = logging.StreamHandler()
     console.setLevel(logging.ERROR)


### PR DESCRIPTION
Per SOFTWARE-1723, osg-configure should set the options in the authorized_only section of /etc/lcmaps.db based on whether the admin wants to use grid-mapfile auth or GUMS auth. This used to be a manual procedure.

Unit tests have been added for this functionality.