### PR TITLE
Allow emails to committers that cause failed builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,3 @@ script:
  # Run tests in Container
  - sudo docker run --rm=true -v `pwd`:/osg-configure:rw centos:centos${OS_VERSION} /bin/bash -c "bash -xe /osg-configure/tests/test_inside_docker.sh ${OS_VERSION}"
 
-notifications:
-  email: false


### PR DESCRIPTION
By default, email notifications are sent to the committer and the commit author, if they are members of the repository (that is, they have push or admin permissions for public repositories, or if they have pull, push or admin permissions for private repositories).

Emails are sent when, on the given branch:

- a build was just broken or still is broken
- a previously broken build was just fixed