### PR TITLE
Put new content into the beginning of the authorize_only section

### DIFF
--- a/tests/configs/misc/lcmaps.db.missing_gridmap.post
+++ b/tests/configs/misc/lcmaps.db.missing_gridmap.post
@@ -19,12 +19,13 @@ bad         = "lcmaps_dummy_bad.mod"
 
 
 authorize_only:
-#gumsclient -> good | bad
 
 ## Added by osg-configure
 ## Set 'edit_lcmaps_db=False' in the [Misc Services] section of your OSG configs
 ## to keep osg-configure from modifying this file
 gridmapfile -> good | bad
+
+#gumsclient -> good | bad
 glexec:
 
 ## Policy 1: GUMS (most common)

--- a/tests/configs/misc/lcmaps.db.missing_gums.post
+++ b/tests/configs/misc/lcmaps.db.missing_gums.post
@@ -19,12 +19,13 @@ bad         = "lcmaps_dummy_bad.mod"
 
 
 authorize_only:
-#gridmapfile -> good | bad
 
 ## Added by osg-configure
 ## Set 'edit_lcmaps_db=False' in the [Misc Services] section of your OSG configs
 ## to keep osg-configure from modifying this file
 gumsclient -> good | bad
+
+#gridmapfile -> good | bad
 glexec:
 
 ## Policy 1: GUMS (most common)


### PR DESCRIPTION
lcmaps.db files come with a comment block before the glexec section that
describes the glexec section. When the new content was placed at the end
of the authorize_only section, it would end up after this comment block,
making it look wrong and confusing. (SOFTWARE-2321)