### PR TITLE
Fix gums_host in unit tests

### DIFF
--- a/tests/configs/misc/valid_settings.ini
+++ b/tests/configs/misc/valid_settings.ini
@@ -1,6 +1,6 @@
 [Misc Services]
 glexec_location = ./configs/misc
 use_cert_updater = True
-gums_host = localhost.localdomain
+gums_host = localhost
 authorization_method = xacml
 enable_webpage_creation = True

--- a/tests/configs/misc/valid_settings.ini
+++ b/tests/configs/misc/valid_settings.ini
@@ -1,6 +1,6 @@
 [Misc Services]
 glexec_location = ./configs/misc
 use_cert_updater = True
-gums_host = my.gums.org
+gums_host = localhost.localdomain
 authorization_method = xacml
 enable_webpage_creation = True

--- a/tests/configs/misc/valid_settings2.ini
+++ b/tests/configs/misc/valid_settings2.ini
@@ -1,6 +1,6 @@
 [Misc Services]
 glexec_location = ./configs/misc
 use_cert_updater = True
-gums_host = my.gums.org
+gums_host = this.should.be.ignored
 authorization_method = local-gridmap
 enable_webpage_creation = True


### PR DESCRIPTION
For SOFTWARE-2406. Some of the unit tests use a config with a value for `gums_host` that is not guaranteed to resolve. Since SOFTWARE-2319, osg-configure has started checking that the value for `gums_host` resolves if using "xacml" as the authentication method. This can lead to test failures. Fix that by using "localhost" as the `gums_host` for that test.

In addition, `gums_host` is meant to be ignored if not using "xacml". Make this explicit by putting a bogus `gums_host` in the test that does uses "local-gridmap" as the auth method.