### PR TITLE
Detect "Resource Entry" section in subcluster.check_config()

### DIFF
--- a/osg_configure/configure_modules/infoservices.py
+++ b/osg_configure/configure_modules/infoservices.py
@@ -151,7 +151,7 @@ class InfoServicesConfiguration(BaseConfiguration):
         self.subcluster_sections = ConfigParser.SafeConfigParser()
 
         for section in configuration.sections():
-            if section.lower().startswith('subcluster'):
+            if section.lower().startswith('subcluster') or section.lower().startswith('resource entry'):
                 self.subcluster_sections.add_section(section)
                 for key, value in configuration.items(section):
                     self.subcluster_sections.set(section, key, value)

--- a/osg_configure/modules/subcluster.py
+++ b/osg_configure/modules/subcluster.py
@@ -158,7 +158,8 @@ def check_config(config):
     """
     has_sc = False
     for section in config.sections():
-        if not section.lower().startswith('subcluster'):
+        lsection = section.lower()
+        if not (lsection.startswith('subcluster') or lsection.startswith('resource entry')):
             continue
         has_sc = True
         check_section(config, section)


### PR DESCRIPTION
This fixes an error when a 30-gip.ini file has a Resource Entry section but not a Subcluster section. (SOFTWARE-2478). Also add a test for this fix.