### PR TITLE
Fix quoting in Gratia probe configs

### DIFF
--- a/osg_configure/configure_modules/gratia.py
+++ b/osg_configure/configure_modules/gratia.py
@@ -719,6 +719,8 @@ in your config.ini file."""
 
           returns the string with the option string replaced/added
         """
+        value = str(value).strip('"')
+
         re_obj = re.compile(r"^(\s*)%s\s*=.*$" % setting, re.MULTILINE)
         (new_buf, count) = re_obj.subn(r'\1%s="%s"' % (setting, value), buf, 1)
         if count == 0:

--- a/osg_configure/configure_modules/gratia.py
+++ b/osg_configure/configure_modules/gratia.py
@@ -357,27 +357,12 @@ in your config.ini file."""
 
         try:
             buf = open(probe_file).read()
-            buf = re.sub(r'(\s*)ProbeName\s*=.*',
-                         r'\1ProbeName="' + "%s:%s" % (probe, hostname) + '"',
-                         buf,
-                         1)
-            buf = re.sub(r'(\s*)SiteName\s*=.*',
-                         r'\1SiteName="' + site + '"',
-                         buf,
-                         1)
-            buf = re.sub(r'(\s*)Grid\s*=.*',
-                         r'\1Grid="' + self.grid_group + '"',
-                         buf,
-                         1)
-            buf = re.sub(r'(\s*)EnableProbe\s*=.*',
-                         r'\1EnableProbe="1"',
-                         buf,
-                         1)
+            buf = self.replace_setting(buf, 'ProbeName', "%s:%s" % (probe, hostname))
+            buf = self.replace_setting(buf, 'SiteName', site)
+            buf = self.replace_setting(buf, 'Grid', self.grid_group)
+            buf = self.replace_setting(buf, 'EnableProbe', '1')
             for var in ['SSLHost', 'SOAPHost', 'SSLRegistrationHost', 'CollectorHost']:
-                buf = re.sub(r'(\s*)' + var + r'\s*=.*',
-                             r'\1' + var + '="' + probe_host + '"',
-                             buf,
-                             1)
+                buf = self.replace_setting(buf, var, probe_host)
 
             if not utilities.atomic_write(probe_file, buf, mode=420):
                 self.log("Error while configuring gratia probes: " +

--- a/osg_configure/configure_modules/gratia.py
+++ b/osg_configure/configure_modules/gratia.py
@@ -704,7 +704,11 @@ in your config.ini file."""
 
           returns the string with the option string replaced/added
         """
-        value = str(value).strip('"')
+        value = str(value)
+        if xml_file:
+            value = value.replace('"', '&quot;')
+        else:
+            value = value.replace('"', '\"')
 
         re_obj = re.compile(r"^(\s*)%s\s*=.*$" % setting, re.MULTILINE)
         (new_buf, count) = re_obj.subn(r'\1%s="%s"' % (setting, value), buf, 1)


### PR DESCRIPTION
This is for SOFTWARE-2311. For Gratia probe configs (ProbeConfig and urCollector.conf files): if the admin added any quotes to the settings in their osg configs, escape the quotes either in XML format (&quot;) for the ProbeConfig files, or in C format (\") for the urCollector.conf files.