### PR TITLE
Don't require some attributes for Resource Entry sections

### DIFF
--- a/osg_configure/modules/subcluster.py
+++ b/osg_configure/modules/subcluster.py
@@ -178,7 +178,7 @@ def resource_catalog_from_config(config, logger=utilities.NullLogger, default_al
 
     rc = resourcecatalog.ResourceCatalog()
 
-    subclusters_without_max_wall_time = []
+    sections_without_max_wall_time = []
     for section in config.sections():
         prefix = None
         if section.lower().startswith('subcluster'):
@@ -191,9 +191,6 @@ def resource_catalog_from_config(config, logger=utilities.NullLogger, default_al
         check_section(config, section)
 
         rcentry = resourcecatalog.RCEntry()
-
-        subcluster = section[len(prefix):].lstrip()
-
         rcentry.name = config.get(section, 'name')
         rcentry.cpus = config.getint(section, 'cores_per_node')
         rcentry.memory = config.getint(section, 'ram_mb')
@@ -202,7 +199,7 @@ def resource_catalog_from_config(config, logger=utilities.NullLogger, default_al
         max_wall_time = utilities.config_safe_get(config, section, 'max_wall_time')
         if not max_wall_time:
             rcentry.max_wall_time = 1440
-            subclusters_without_max_wall_time.append(subcluster)
+            sections_without_max_wall_time.append(section)
         else:
             rcentry.max_wall_time = max_wall_time.strip()
         rcentry.queue = utilities.config_safe_get(config, section, 'queue')
@@ -215,9 +212,9 @@ def resource_catalog_from_config(config, logger=utilities.NullLogger, default_al
         rc.add_rcentry(rcentry)
     # end for section in config.sections()
 
-    if subclusters_without_max_wall_time:
-        logger.warning("No max_wall_time specified for some subclusters; defaulting to 1440."
-                       "\nAdd 'max_wall_time=1440' to the following subcluster(s) to clear this warning:"
-                       "\n%s" % ", ".join(subclusters_without_max_wall_time))
+    if sections_without_max_wall_time:
+        logger.warning("No max_wall_time specified for some sections; defaulting to 1440."
+                       "\nAdd 'max_wall_time=1440' to the following section(s) to clear this warning:"
+                       "\n'%s'" % "', '".join(sections_without_max_wall_time))
 
     return rc

--- a/tests/configs/gip/resourceentry.ini
+++ b/tests/configs/gip/resourceentry.ini
@@ -12,5 +12,11 @@ inbound_network = FALSE
 outbound_network = TRUE
 HEPSPEC = 10
 
+[Resource Entry Valid 2]
+name = red.unl.edu
+ram_mb = 4000
+cores_per_node = 4
+
+
 [PBS]
 enabled = True

--- a/tests/test_gip.py
+++ b/tests/test_gip.py
@@ -453,6 +453,22 @@ class TestGip(unittest.TestCase):
         found_scs = gip_config.check_subclusters(config_parser)
         self.assertTrue(found_scs, msg="Resource Entry Valid not found.")
 
+    def test_resource_entry_2(self):
+        """
+        Make sure most subcluster attributes are optional for a
+        Resource Entry section
+        """
+        config_parser = ConfigParser.SafeConfigParser()
+        config_file = get_test_config("gip/resourceentry.ini")
+        config_parser.read(config_file)
+        gip_config = gip.GipConfiguration(logger=global_logger)
+        did_fail = False
+        try:
+            gip_config.check_sc(config_parser, "Resource Entry Valid 2")
+        except exceptions.SettingError:
+            did_fail = True
+        self.assertFalse(did_fail, msg="Valid Resource Entry section threw an exception.")
+
     def test_user_check_invalid_user(self):
         """
         Check to make sure gip class will distinguish between valid and


### PR DESCRIPTION
SOFTWARE-2554. Unlike Subcluster sections, Resource Entry sections are not used for GIP/BDII, only for the CE collector and AGiS. Allow omitting attributes from Resource Entry sections that aren't needed for the latter two systems.