### PR TITLE
Turn a missing `app_dir` into a warning, not an error

### DIFF
--- a/osg_configure/configure_modules/storage.py
+++ b/osg_configure/configure_modules/storage.py
@@ -102,11 +102,8 @@ class StorageConfiguration(BaseConfiguration):
         # warn if locations don't exist
         app_dir = self.options['app_dir'].value
         if not self._check_app_dir(app_dir):
-            self.log("{app_dir} and/or {app_dir}/etc were not found or have the wrong permissions. These are used for"
-                     " $OSG_APP and $OSG_APP/etc on worker nodes, where they should exist and have permissions of"
-                     " 1777 or 777.".format(app_dir=app_dir),
-                     section=self.config_section,
-                     option='app_dir',
+            self.log("app_dir is used for $OSG_APP and $OSG_APP/etc on worker nodes, where they should exist and"
+                     " have permissions of 1777 or 777.",
                      level=logging.WARNING)
 
         # WN_TMP may be blank if the job manager dynamically generates it but

--- a/osg_configure/configure_modules/storage.py
+++ b/osg_configure/configure_modules/storage.py
@@ -218,7 +218,7 @@ class StorageConfiguration(BaseConfiguration):
                 self.log("Directory not present: %s" % app_dir,
                          section=self.config_section,
                          option='app_dir',
-                         level=logging.ERROR)
+                         level=logging.WARNING)
                 return False
 
             etc_dir = os.path.join(app_dir, "etc")
@@ -226,7 +226,7 @@ class StorageConfiguration(BaseConfiguration):
                 self.log("$OSG_APP/etc directory not present: %s" % etc_dir,
                          section=self.config_section,
                          option='app_dir',
-                         level=logging.ERROR)
+                         level=logging.WARNING)
                 return False
 
             permissions = stat.S_IMODE(os.stat(etc_dir).st_mode)

--- a/osg_configure/configure_modules/storage.py
+++ b/osg_configure/configure_modules/storage.py
@@ -99,14 +99,15 @@ class StorageConfiguration(BaseConfiguration):
             self.log('StorageConfiguration.check_attributes completed')
             return attributes_ok
 
-        # make sure locations exist
-        if not self._check_app_dir(self.options['app_dir'].value):
-            self.log("The app_dir and app_dir/etc directories should exist and " +
-                     "have permissions of 1777 or 777 on OSG installations.",
+        # warn if locations don't exist
+        app_dir = self.options['app_dir'].value
+        if not self._check_app_dir(app_dir):
+            self.log("{app_dir} and/or {app_dir}/etc were not found or have the wrong permissions. These are used for"
+                     " $OSG_APP and $OSG_APP/etc on worker nodes, where they should exist and have permissions of"
+                     " 1777 or 777.".format(app_dir=app_dir),
                      section=self.config_section,
                      option='app_dir',
-                     level=logging.ERROR)
-            attributes_ok = False
+                     level=logging.WARNING)
 
         # WN_TMP may be blank if the job manager dynamically generates it but
         # warni just in case


### PR DESCRIPTION
This is for SOFTWARE-2674.