### PR TITLE
Fixes for SOFTWARE-2482 (v1)

### DIFF
--- a/osg_configure/configure_modules/infoservices.py
+++ b/osg_configure/configure_modules/infoservices.py
@@ -344,7 +344,7 @@ CONDOR_VIEW_HOST = %s
 
 
 def ensure_valid_user_vo_file(using_gums, gums_host=None, logger=utilities.NullLogger):
-    if not validation.valid_user_vo_file(USER_VO_MAP_LOCATION):
+    if not (validation.valid_user_vo_file(USER_VO_MAP_LOCATION) and utilities.get_vos(USER_VO_MAP_LOCATION)):
         logger.info("Trying to create user-vo-map file")
         if using_gums:
             try:

--- a/osg_configure/configure_modules/infoservices.py
+++ b/osg_configure/configure_modules/infoservices.py
@@ -352,11 +352,12 @@ def ensure_valid_user_vo_file(using_gums, gums_host=None, logger=utilities.NullL
         logger.info("Trying to create user-vo-map file")
         if using_gums:
             try:
+                logger.info("Querying GUMS server via JSON interface. This may take some time")
                 user_vo_file_text = gums_supported_vos.gums_json_user_vo_map_file(gums_host)
                 open(USER_VO_MAP_LOCATION, "w").write(user_vo_file_text)
                 return True
             except exceptions.ApplicationError, e:
-                self.log("Could not query GUMS server via JSON interface: %s" % e, level=logging.WARNING)
+                logger.warning("Could not query GUMS server via JSON interface, falling back to gums-host-cron: %s" % e)
 
             gums_script = '/usr/bin/gums-host-cron'
         else:

--- a/osg_configure/configure_modules/infoservices.py
+++ b/osg_configure/configure_modules/infoservices.py
@@ -200,11 +200,7 @@ class InfoServicesConfiguration(BaseConfiguration):
                 else:
                     using_gums = self.authorization_method == 'xacml'
                     ensure_valid_user_vo_file(using_gums, gums_host=self.gums_host, logger=self.logger)
-                    try:
-                        default_allowed_vos = gums_supported_vos.gums_supported_vos(self.gums_host)
-                    except exceptions.ApplicationError, e:
-                        self.log("Could not query GUMS server via JSON interface: %s" % e, level=logging.WARNING)
-                        default_allowed_vos = utilities.get_vos(USER_VO_MAP_LOCATION)
+                    default_allowed_vos = utilities.get_vos(USER_VO_MAP_LOCATION)
                 if not default_allowed_vos:
                     # UGLY: only issue the warning if the admin has requested autodetection for some of their SCs/REs
                     raise_warning = False


### PR DESCRIPTION
This fixes logging in ensure_valid_user_vo_file and makes it so that the gums server doesn't get queried if there's already a working user-vo-map, which should get rid of the performance issues.

Known issues:
* the 'this may take a while' warning only shows up in the logfile, which is pretty useless. I think it will be fixed when I get around to fixing the logging (SOFTWARE-2744)
* the user-vo-map file gets populated once, and then never updated; normally, gums-host-cron runs from cron and updates it. I will make a new ticket for that
