### PR TITLE
Always use /usr/sbin/fetch-crl (SOFTWARE-2891)

### DIFF
--- a/osg_configure/modules/utilities.py
+++ b/osg_configure/modules/utilities.py
@@ -227,11 +227,7 @@ def fetch_crl():
             sys.stdout.flush()
             return True
 
-        crl_path = '/usr/sbin'
-        if rpm_installed('fetch-crl'):
-            crl_path = os.path.join(crl_path, 'fetch-crl')
-        elif rpm_installed('fetch-crl3'):
-            crl_path = os.path.join(crl_path, 'fetch-crl3')
+        crl_path = '/usr/sbin/fetch-crl'
 
         # Some CRLs are often problematic; it's better to ignore some errors than to halt configuration. (SOFTWARE-1428)
         error_message_whitelist = [  # whitelist partially taken from osg-test


### PR DESCRIPTION
This solves trying to run `/usr/sbin` when no fetch-crl package is found.
No need to detect whether fetch-crl or fetch-crl3 is installed --
fetch-crl3 does not exist on RHEL > 5.
Missing /usr/sbin/fetch-crl is already handled.