### PR TITLE
Validate Local Settings vars (SOFTWARE-3131)

### DIFF
--- a/osg_configure/configure_modules/localsettings.py
+++ b/osg_configure/configure_modules/localsettings.py
@@ -1,7 +1,9 @@
 """ Module to handle site specific local settings """
 
 import logging
+import re
 from osg_configure.modules.baseconfiguration import BaseConfiguration
+from osg_configure.modules.exceptions import SettingError
 
 __all__ = ['LocalSettings']
 
@@ -47,6 +49,12 @@ class LocalSettings(BaseConfiguration):
             if name in configuration.defaults():
                 self.log("%s is a default, skipping" % (name))
                 continue
+            # Validate name because it will be used as the name of an env var
+            if not re.match(r"[A-Za-z_][A-Za-z0-9_]*$", name):
+                raise SettingError("Invalid variable name " + name)
+            # Values are already double-quoted so adding quotes would be a syntax error
+            if value.startswith('"') or value.rstrip().endswith('"'):
+                raise SettingError("Value for " + name + " should not be quoted")
             self.attributes[name] = value
         self.log('LocalSettings.parse_configuration completed')
 

--- a/tests/configs/localsettings/bogusquote.ini
+++ b/tests/configs/localsettings/bogusquote.ini
@@ -1,0 +1,2 @@
+[Local Settings]
+http_proxy = "http://example.net:3128"

--- a/tests/configs/localsettings/bogusvarname.ini
+++ b/tests/configs/localsettings/bogusvarname.ini
@@ -1,0 +1,2 @@
+[Local Settings]
+http_proxy - "http://example.net:3128"

--- a/tests/configs/localsettings/local_settings1.ini
+++ b/tests/configs/localsettings/local_settings1.ini
@@ -1,6 +1,5 @@
 [Default]
-default-key = 'default'
+default_key = 'default'
 
 [Local Settings]
 test1 = Value1
-Test2- = Val03-42

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -74,6 +74,18 @@ class TestLocalSettings(unittest.TestCase):
                           configuration)
 
 
+    def testBogusQuote(self):
+        config_file = get_test_config("localsettings/bogusquote.ini")
+        configuration = ConfigParser.SafeConfigParser()
+        configuration.optionxform = str
+        configuration.read(config_file)
+
+        settings = localsettings.LocalSettings(logger=global_logger)
+        self.assertRaises(exceptions.SettingError,
+                          settings.parse_configuration,
+                          configuration)
+
+
 if __name__ == '__main__':
     console = logging.StreamHandler()
     console.setLevel(logging.ERROR)

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -15,6 +15,7 @@ sys.path.insert(0, pathname)
 
 from osg_configure.configure_modules import localsettings
 from osg_configure.modules.utilities import get_test_config
+from osg_configure.modules import exceptions
 
 # NullHandler is only available in Python 2.7+
 try:
@@ -55,16 +56,22 @@ class TestLocalSettings(unittest.TestCase):
         self.assertEqual(attributes['test1'], 'Value1',
                          'Wrong value obtained for test1')
 
-        self.assertTrue(attributes.has_key('Test2-'),
-                        'Attribute Test2- missing')
-        self.assertEqual(attributes['Test2-'], 'Val03-42',
-                         'Wrong value obtained for Test2-')
+        self.assertFalse(attributes.has_key('missing_key'),
+                         'Non-existent key (missing_key) found')
 
-        self.assertFalse(attributes.has_key('missing-key'),
-                         'Non-existent key (missing-key) found')
-
-        self.assertFalse(attributes.has_key('default-key'),
+        self.assertFalse(attributes.has_key('default_key'),
                          'Default key recognized as a local attribute')
+
+    def testBogusVarName(self):
+        config_file = get_test_config("localsettings/bogusvarname.ini")
+        configuration = ConfigParser.SafeConfigParser()
+        configuration.optionxform = str
+        configuration.read(config_file)
+
+        settings = localsettings.LocalSettings(logger=global_logger)
+        self.assertRaises(exceptions.SettingError,
+                          settings.parse_configuration,
+                          configuration)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make sure the attributes in the Local Settings section are valid identifiers -- meaning they can be used as bash variables. Also check that the user didn't quote the value (since they already get quoted in the files osg-configure generates).