### PR TITLE
Modernize Python syntax

### DIFF
--- a/osg_configure/configure_modules/bosco.py
+++ b/osg_configure/configure_modules/bosco.py
@@ -198,7 +198,7 @@ class BoscoConfiguration(JobManagerConfiguration):
         # First, get the uid of the username so we can seteuid
         try:
             user_info = pwd.getpwnam(username)
-        except KeyError, e:
+        except KeyError as e:
             self.log("Error finding username: %s on system." % username, level=logging.ERROR)
             return False
         
@@ -286,7 +286,7 @@ Host %(host)s
                 self.log("stdout:\n%s" % stdout, level=logging.DEBUG)
                 self.log("stderr:\n%s" % stderr, level=logging.DEBUG)
 
-        except Exception, e:
+        except Exception as e:
             self.log("Error in bosco installation: %s" % str(e), level=logging.ERROR)
             return False
             

--- a/osg_configure/configure_modules/gratia.py
+++ b/osg_configure/configure_modules/gratia.py
@@ -335,7 +335,7 @@ in your config.ini file."""
                     self.log("Subscription for %s in %s found" % (probe_host, probe_file))
                     return True
             # pylint: disable-msg=W0703
-            except Exception, e:
+            except Exception as e:
                 self.log("Exception checking element, %s" % e)
 
         self.log("GratiaConfiguration._subscription_present completed")
@@ -658,7 +658,7 @@ in your config.ini file."""
                                                                                    history_dir),
                                      level=logging.ERROR)
                             valid = False
-                    except OSError, e:
+                    except OSError as e:
                         self.log("Error comparing DataFolder setting in %s (%s) and condor PER_JOB_HISTORY_DIR %s:\n%s"
                                  % (config_location, data_folder, history_dir, e),
                                  level=logging.ERROR)
@@ -682,7 +682,7 @@ in your config.ini file."""
                                                                                                errtext),
                          level=logging.INFO)
                 return None
-        except OSError, err:
+        except OSError as err:
             self.log("While checking gratia parameters: Error running %s: %s" % (condor_config_val_bin, str(err)),
                      level=logging.INFO)
             return None

--- a/osg_configure/configure_modules/rsv.py
+++ b/osg_configure/configure_modules/rsv.py
@@ -782,7 +782,7 @@ class RsvConfiguration(BaseConfiguration):
                                                                condor_dir))
                 sysconf.write("export PATH\n")
             sysconf.close()
-        except IOError, err:
+        except IOError as err:
             self.log("Error trying to write to file (%s): %s" % (sysconf_file, err))
             raise exceptions.ConfigureError
 
@@ -793,7 +793,7 @@ class RsvConfiguration(BaseConfiguration):
             if self.options['condor_location'].value:
                 config.write("RELEASE_DIR = %s" % condor_dir)
             config.close()
-        except IOError, err:
+        except IOError as err:
             self.log("Error trying to write to file (%s): %s" % (conf_file, err))
             raise exceptions.ConfigureError
 
@@ -920,7 +920,7 @@ class RsvConfiguration(BaseConfiguration):
         try:
             try:
                 config.write(config_fp)
-            except EnvironmentError, err:
+            except EnvironmentError as err:
                 self.log("Error writing to %s: %s" % (allmetrics_conf_path, str(err)), level=logging.ERROR)
                 raise exceptions.ConfigureError
         finally:
@@ -966,7 +966,7 @@ class RsvConfiguration(BaseConfiguration):
         # The Nagios conf file contains a password so set it to mode 0400 owned by rsv
         pw_file = os.path.join(self.rsv_conf_dir, 'rsv-nagios.conf')
         os.chown(pw_file, self.uid, self.gid)
-        os.chmod(pw_file, 0400)
+        os.chmod(pw_file, 0o400)
 
         # Add the configuration file
         nagios_conf_file = os.path.join(self.rsv_conf_dir, 'consumers/nagios-consumer.conf')
@@ -1113,21 +1113,21 @@ class RsvConfiguration(BaseConfiguration):
 
         log_folder = os.path.join(parent_dir, 'logs')
         if not os.path.exists(log_folder):
-            utilities.make_directory(log_folder, 0755, self.uid, self.gid)
+            utilities.make_directory(log_folder, 0o755, self.uid, self.gid)
         elif os.path.isdir(log_folder):
             os.chown(log_folder, self.uid, self.gid)
         conf = re.sub(r'(\s*)LogFolder\s*=.*', r'\1LogFolder="' + log_folder + '"', conf, 1)
 
         data_folder = os.path.join(parent_dir, 'data')
         if not os.path.exists(data_folder):
-            utilities.make_directory(data_folder, 0755, self.uid, self.gid)
+            utilities.make_directory(data_folder, 0o755, self.uid, self.gid)
         elif os.path.isdir(data_folder):
             os.chown(data_folder, self.uid, self.gid)
         conf = re.sub(r'(\s*)DataFolder\s*=.*', r'\1DataFolder="' + data_folder + '"', conf, 1)
 
         working_folder = os.path.join(parent_dir, 'tmp')
         if not os.path.exists(working_folder):
-            utilities.make_directory(working_folder, 0755, self.uid, self.gid)
+            utilities.make_directory(working_folder, 0o755, self.uid, self.gid)
         elif os.path.isdir(working_folder):
             os.chown(working_folder, self.uid, self.gid)
         conf = re.sub(r'(\s*)WorkingFolder\s*=.*',

--- a/osg_configure/configure_modules/storage.py
+++ b/osg_configure/configure_modules/storage.py
@@ -162,7 +162,7 @@ class StorageConfiguration(BaseConfiguration):
                          level=logging.WARNING)
             try:
                 if validation.valid_file(grid3_location):
-                    os.chmod(grid3_location, 0666)
+                    os.chmod(grid3_location, 0o666)
             except IOError:
                 self.log("Can't set permissions on grid3-location file at %s" % \
                          (grid3_location),

--- a/osg_configure/modules/baseconfiguration.py
+++ b/osg_configure/modules/baseconfiguration.py
@@ -276,13 +276,13 @@ class BaseConfiguration(object):
                 parent_dir = os.path.abspath(os.path.dirname(to_path))
                 try:
                     os.makedirs(parent_dir)
-                except OSError, err:
+                except OSError as err:
                     if err.errno != errno.EEXIST:
                         self.log("Could not create directory %s" % parent_dir, exception=err, level=logging.ERROR)
                         return False
                 try:
                     os.chown(parent_dir, user_pwd.pw_uid, user_pwd.pw_gid)
-                except EnvironmentError, err:
+                except EnvironmentError as err:
                     self.log("Could not set ownership of %s" % parent_dir, exception=err, level=logging.ERROR)
                     return False
                 from_fh = open(from_path, 'rb')
@@ -293,7 +293,7 @@ class BaseConfiguration(object):
                     return False
                 try:
                     os.chown(to_path, user_pwd.pw_uid, user_pwd.pw_gid)
-                except EnvironmentError, err:
+                except EnvironmentError as err:
                     self.log("Could not set ownership of %s" % to_path, exception=err, level=logging.ERROR)
                     return False
 

--- a/osg_configure/modules/configfile.py
+++ b/osg_configure/modules/configfile.py
@@ -47,7 +47,7 @@ def read_config_files(**kwargs):
         config = ConfigParser.SafeConfigParser()
         if case_sensitive:
             config.optionxform = str
-    except ConfigParser.Error, e:
+    except ConfigParser.Error as e:
         raise IOError("Can't read and parse config files:\n%s" % e)
     read_files = config.read(file_list)
     read_files.sort()
@@ -84,7 +84,7 @@ def get_option_location(option, section, **kwargs):
             config.readfp(open(fn, 'r'))
             if config.has_option(section, option):
                 return fn
-        except ConfigParser.Error, e:
+        except ConfigParser.Error as e:
             raise Exception("Can't parse %s:\n%s" % (fn, e))
 
     return None

--- a/osg_configure/modules/gums_supported_vos.py
+++ b/osg_configure/modules/gums_supported_vos.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import os
 import re
 import pwd
@@ -80,12 +81,12 @@ def gums_json_vo_user_map(gums_host, target_host=None,
     params   = {'hostname': target_host}
     try:
         json_map = gums_json_map(gums_host, json_cmd, params, certpath, keypath)
-    except EnvironmentError, e:
+    except EnvironmentError as e:
         raise exceptions.Error(
             "Error contacting gums host via json interface: %s" % e)
 
     if _debug:
-        print json_map
+        print(json_map)
 
     if 'result' not in json_map:
         raise exceptions.Error("'result' not in returned json")
@@ -111,12 +112,12 @@ def gums_json_user_vo_map_file(gums_host, target_host=None,
     params   = {'hostname': target_host}
     try:
         json_map = gums_json_map(gums_host, json_cmd, params, certpath, keypath)
-    except EnvironmentError, e:
+    except EnvironmentError as e:
         raise exceptions.Error(
             "Error contacting gums host via json interface: %s" % e)
 
     if _debug:
-        print json_map
+        print(json_map)
 
     if 'result' not in json_map:
         raise exceptions.Error("'result' not in returned json")

--- a/osg_configure/modules/utilities.py
+++ b/osg_configure/modules/utilities.py
@@ -121,7 +121,7 @@ def write_attribute_file(filename=None, attributes=None):
     """
     if filename:
         file_contents = _compose_attribute_file(attributes or {})
-        atomic_write(filename, file_contents, mode=0644)
+        atomic_write(filename, file_contents, mode=0o644)
 
 
 def get_set_membership(test_set, reference_set, defaults=None):

--- a/osg_configure/modules/validation.py
+++ b/osg_configure/modules/validation.py
@@ -251,7 +251,7 @@ def valid_ini_file(filename):
     file_buffer.seek(0)
     try:
         configuration.readfp(file_buffer)
-    except ConfigParser.ParsingError, e:
+    except ConfigParser.ParsingError as e:
         sys.stderr.write("Error while parsing: %s\n%s\n" % (filename, e))
         sys.stderr.write("Lines with options should not start with a space\n")
         return False
@@ -286,7 +286,7 @@ def valid_ini_references(files):
     configuration = ConfigParser.SafeConfigParser()
     try:
         configuration.read(files)
-    except ConfigParser.InterpolationError, e:
+    except ConfigParser.InterpolationError as e:
         sys.stderr.write("Error with variable interpolation:\n%s\n" % e)
         return False
 

--- a/scripts/osg-configure
+++ b/scripts/osg-configure
@@ -81,7 +81,7 @@ def get_configuration_modules():
     try:
         module_dirs = os.path.split(os.path.dirname(utilities.__file__))[0]
         modules = os.listdir(os.path.join(module_dirs, "configure_modules"))
-    except OSError, exception:
+    except OSError as exception:
         error_exit("Can't get configuration modules, exiting...", exception)
 
     objects = []
@@ -126,7 +126,7 @@ def write_attributes(attributes, local_site_attributes, job_environment_attribut
     try:
         filename = os.path.join(OUTPUT_DIRECTORY, "osg-local-job-environment.conf")
         utilities.write_attribute_file(filename, local_site_attributes)
-    except IOError, exception:
+    except IOError as exception:
         error_exit("Error writing attributes to osg-local-job-environment.conf", exception)
 
 
@@ -137,7 +137,7 @@ def write_attributes(attributes, local_site_attributes, job_environment_attribut
         for key in job_environment_attributes:
             try:
                 temp[key] = attributes[key]
-            except KeyError, exception:
+            except KeyError as exception:
                 if key == 'OSG_SQUID_LOCATION':
                     continue
                 else:
@@ -151,7 +151,7 @@ def write_attributes(attributes, local_site_attributes, job_environment_attribut
                                 errmsg += "Option %r\n" % (name)
                     error_exit(errmsg, exception)
         utilities.write_attribute_file(filename, temp)
-    except IOError, exception:
+    except IOError as exception:
         error_exit("Error writing attributes to osg-job-environment.conf", exception)
 
 
@@ -172,7 +172,7 @@ def configure_system(modules, configure_module=None, force=False):
 
     try:
         config = configfile.read_config_files()
-    except IOError, e:
+    except IOError as e:
         error_exit("Can't read configuration files: %s" % e)
 
     for module in modules:
@@ -184,11 +184,11 @@ def configure_system(modules, configure_module=None, force=False):
                 continue
             else:
                 module.parse_configuration(config)
-        except exceptions.SettingError, exception:
+        except exceptions.SettingError as exception:
             error_exit("Error in %s while parsing configuration" % \
                        (module.__class__.__name__),
                        exception)
-        except ConfigParser.ParsingError, exception:
+        except ConfigParser.ParsingError as exception:
             error_exit("Error while parsing configuration: %s" % exception)
 
     attributes = {}
@@ -226,7 +226,7 @@ def configure_system(modules, configure_module=None, force=False):
                 continue
         try:
             module.configure(attributes)
-        except exceptions.ConfigureError, e:
+        except exceptions.ConfigureError as e:
             logging.debug("Got ConfigureError %s" % e)
             error_exit("Can't configure module, exiting")
 
@@ -282,7 +282,7 @@ def query_option(modules, option=None):
 
     try:
         config = configfile.read_config_files()
-    except IOError, e:
+    except IOError as e:
         error_exit("Can't read configuration files: %s" % e)
 
     if '.' in option:
@@ -345,17 +345,17 @@ def list_enabled_services(modules):
 
     try:
         config = configfile.read_config_files()
-    except IOError, e:
+    except IOError as e:
         error_exit("Can't read configuration files: %s" % e)
 
     for module in modules:
         try:
             module.parse_configuration(config)
-        except exceptions.SettingError, exception:
+        except exceptions.SettingError as exception:
             error_exit("Error in %s while parsing configuration" % \
                        (module.__class__.__name__),
                        exception)
-        except ConfigParser.ParsingError, exception:
+        except ConfigParser.ParsingError as exception:
             error_exit("Error while parsing configuration: %s" % exception)
 
     sys.stdout.write("System services associated with current configuration:\n")
@@ -381,7 +381,7 @@ def verify_system(modules):
 
     try:
         config = configfile.read_config_files()
-    except IOError, e:
+    except IOError as e:
         error_exit("Can't read configuration files: %s" % e)
 
     for module in modules:
@@ -392,10 +392,10 @@ def verify_system(modules):
                 continue
             else:
                 module.parse_configuration(config)
-        except exceptions.SettingError, exception:
+        except exceptions.SettingError as exception:
             error_exit("Error in %s while parsing configuration" % (module.__class__.__name__),
                        exception)
-        except ConfigParser.ParsingError, exception:
+        except ConfigParser.ParsingError as exception:
             error_exit("Error while parsing configuration: %s" % exception)
 
     attributes = {}
@@ -447,7 +447,7 @@ def check_configuration(modules, attributes):
 
     try:
         configfile.read_config_files()
-    except IOError, e:
+    except IOError as e:
         error_exit("Can't read configuration files: %s" % e)
 
     status = True
@@ -531,7 +531,7 @@ def main():
         error_exit("You must be root when running %s" % sys.argv[0])
 
     # Set the umask so we get the right permissions on files
-    os.umask(022)
+    os.umask(0o22)
 
     if 'VDT_LOCATION' in os.environ:
         error_exit("$VDT_LOCATION exists in the environment, it looks like " +
@@ -602,7 +602,7 @@ def main():
     except SystemExit:
         # needed since SystemExit inherits from Exception
         raise
-    except Exception, e:
+    except Exception as e:
         debug_info = "Unhandled exception %s\n%s" % (e, traceback.format_exc())
         if logger:
             logger.debug(debug_info)

--- a/tests/test_condor.py
+++ b/tests/test_condor.py
@@ -46,7 +46,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -74,7 +74,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -93,7 +93,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -116,7 +116,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -136,7 +136,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -161,7 +161,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -184,7 +184,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -211,7 +211,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -233,7 +233,7 @@ class TestCondor(unittest.TestCase):
             settings = condor.CondorConfiguration(logger=global_logger)
             try:
                 settings.parse_configuration(configuration)
-            except Exception, e:
+            except Exception as e:
                 self.fail("Received exception while parsing configuration: %s" % e)
 
             attributes = settings.get_attributes()
@@ -253,7 +253,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -272,7 +272,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -291,7 +291,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set(['condor-ce', 'globus-gridftp-server'])
@@ -306,7 +306,7 @@ class TestCondor(unittest.TestCase):
         settings = condor.CondorConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -38,7 +38,7 @@ class TestGateway(unittest.TestCase):
         settings = gateway.GatewayConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         options = settings.options

--- a/tests/test_gratia.py
+++ b/tests/test_gratia.py
@@ -47,7 +47,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         options = settings.options
@@ -77,7 +77,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         options = settings.options
@@ -106,7 +106,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         options = settings.options
@@ -135,7 +135,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         options = settings.options
@@ -155,7 +155,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         options = settings.options
@@ -184,7 +184,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         options = settings.options
@@ -209,7 +209,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         self.assertEqual(len(settings.options['probes'].value),
@@ -228,7 +228,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         self.assertEqual(len(settings.options['probes'].value),
@@ -248,7 +248,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -267,7 +267,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -288,7 +288,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -309,7 +309,7 @@ class TestGratia(unittest.TestCase):
         except OSError:
             # Need to rewrite or remove this test due to new checks with condor
             pass
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -329,7 +329,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -350,7 +350,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -369,7 +369,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -388,7 +388,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set(['gratia-probes-cron'])
@@ -403,7 +403,7 @@ class TestGratia(unittest.TestCase):
         settings = gratia.GratiaConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()

--- a/tests/test_info_services.py
+++ b/tests/test_info_services.py
@@ -7,6 +7,7 @@
 # pylint: disable=W0703
 # pylint: disable=R0904
 
+from __future__ import print_function
 import os
 import sys
 import unittest
@@ -54,7 +55,7 @@ class TestInfoServices(unittest.TestCase):
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
     def testParsingIgnored(self):
@@ -70,7 +71,7 @@ class TestInfoServices(unittest.TestCase):
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
     def testValidSettings2(self):
@@ -86,7 +87,7 @@ class TestInfoServices(unittest.TestCase):
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -107,7 +108,7 @@ class TestInfoServices(unittest.TestCase):
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -128,7 +129,7 @@ class TestInfoServices(unittest.TestCase):
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -148,7 +149,7 @@ class TestInfoServices(unittest.TestCase):
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -47,7 +47,7 @@ class TestLocalSettings(unittest.TestCase):
         settings = localsettings.LocalSettings(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()

--- a/tests/test_lsf.py
+++ b/tests/test_lsf.py
@@ -46,7 +46,7 @@ class TestLSF(unittest.TestCase):
         settings = lsf.LSFConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -73,7 +73,7 @@ class TestLSF(unittest.TestCase):
         settings = lsf.LSFConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -93,7 +93,7 @@ class TestLSF(unittest.TestCase):
         settings = lsf.LSFConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -112,7 +112,7 @@ class TestLSF(unittest.TestCase):
         settings = lsf.LSFConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -143,7 +143,7 @@ class TestLSF(unittest.TestCase):
         settings = lsf.LSFConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -161,7 +161,7 @@ class TestLSF(unittest.TestCase):
         settings = lsf.LSFConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -180,7 +180,7 @@ class TestLSF(unittest.TestCase):
         settings = lsf.LSFConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set(['condor-ce', 'globus-gridftp-server'])
@@ -195,7 +195,7 @@ class TestLSF(unittest.TestCase):
         settings = lsf.LSFConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -49,7 +49,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         options = settings.options
@@ -75,7 +75,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         options = settings.options
@@ -101,7 +101,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         self.assertTrue(settings.options.has_key('authorization_method'),
@@ -120,7 +120,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         self.assertTrue(settings.options.has_key('authorization_method'),
@@ -139,7 +139,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         self.assertTrue(settings.options.has_key('authorization_method'),
@@ -195,7 +195,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -214,7 +214,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -233,7 +233,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -252,7 +252,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -271,7 +271,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         if utilities.rpm_installed('fetch-crl'):
@@ -292,7 +292,7 @@ class TestMisc(unittest.TestCase):
         settings = misc.MiscConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         if utilities.rpm_installed('fetch-crl'):

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -45,7 +45,7 @@ class TestPBS(unittest.TestCase):
         settings = pbs.PBSConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -72,7 +72,7 @@ class TestPBS(unittest.TestCase):
         settings = pbs.PBSConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -91,7 +91,7 @@ class TestPBS(unittest.TestCase):
         settings = pbs.PBSConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -109,7 +109,7 @@ class TestPBS(unittest.TestCase):
         settings = pbs.PBSConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -127,7 +127,7 @@ class TestPBS(unittest.TestCase):
         settings = pbs.PBSConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -145,7 +145,7 @@ class TestPBS(unittest.TestCase):
         settings = pbs.PBSConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -164,7 +164,7 @@ class TestPBS(unittest.TestCase):
         settings = pbs.PBSConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set(['condor-ce',
@@ -180,7 +180,7 @@ class TestPBS(unittest.TestCase):
         settings = pbs.PBSConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()
@@ -195,7 +195,7 @@ class TestPBS(unittest.TestCase):
         settings = pbs.PBSConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()

--- a/tests/test_resourcecatalog.py
+++ b/tests/test_resourcecatalog.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest, os, sys
 import cStringIO
 import ConfigParser

--- a/tests/test_sge.py
+++ b/tests/test_sge.py
@@ -46,7 +46,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -75,7 +75,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -94,7 +94,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -132,7 +132,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -151,7 +151,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -170,7 +170,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -191,7 +191,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -212,7 +212,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -231,7 +231,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set(['condor-ce',
@@ -247,7 +247,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()
@@ -262,7 +262,7 @@ class TestSGE(unittest.TestCase):
         settings = sge.SGEConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()

--- a/tests/test_siteattributes.py
+++ b/tests/test_siteattributes.py
@@ -46,7 +46,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -81,7 +81,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -116,7 +116,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -153,7 +153,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         mandatory_on_all = ['group']
@@ -193,7 +193,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -207,7 +207,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -227,7 +227,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -241,7 +241,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -261,7 +261,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -281,7 +281,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -302,7 +302,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -323,7 +323,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -342,7 +342,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -361,7 +361,7 @@ class TestSiteAttributes(unittest.TestCase):
         settings = siteinformation.SiteInformation(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -45,7 +45,7 @@ class TestSlurm(unittest.TestCase):
         settings = slurm.SlurmConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -72,7 +72,7 @@ class TestSlurm(unittest.TestCase):
         settings = slurm.SlurmConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -91,7 +91,7 @@ class TestSlurm(unittest.TestCase):
         settings = slurm.SlurmConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -109,7 +109,7 @@ class TestSlurm(unittest.TestCase):
         settings = slurm.SlurmConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -127,7 +127,7 @@ class TestSlurm(unittest.TestCase):
         settings = slurm.SlurmConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -145,7 +145,7 @@ class TestSlurm(unittest.TestCase):
         settings = slurm.SlurmConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -164,7 +164,7 @@ class TestSlurm(unittest.TestCase):
         settings = slurm.SlurmConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set(['condor-ce',
@@ -180,7 +180,7 @@ class TestSlurm(unittest.TestCase):
         settings = slurm.SlurmConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()
@@ -195,7 +195,7 @@ class TestSlurm(unittest.TestCase):
         settings = slurm.SlurmConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
         services = settings.enabled_services()
         expected_services = set()

--- a/tests/test_squid.py
+++ b/tests/test_squid.py
@@ -47,7 +47,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -75,7 +75,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -103,7 +103,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -127,7 +127,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -210,7 +210,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -224,7 +224,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration")
 
         attributes = settings.get_attributes()
@@ -246,7 +246,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -267,7 +267,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -287,7 +287,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -309,7 +309,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -329,7 +329,7 @@ class TestSquid(unittest.TestCase):
         settings = squid.SquidConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -52,7 +52,7 @@ class TestStorage(unittest.TestCase):
         settings = storage.StorageConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -74,7 +74,7 @@ class TestStorage(unittest.TestCase):
         if not validation.valid_directory('/tmp/etc'):
             # handle cases where this is not run under osg test framework
             os.mkdir('/tmp/etc')
-            os.chmod('/tmp/etc', 0777)
+            os.chmod('/tmp/etc', 0o777)
             self.assertTrue(settings.check_attributes(attributes))
             os.rmdir('/tmp/etc')
         else:
@@ -95,7 +95,7 @@ class TestStorage(unittest.TestCase):
         settings = storage.StorageConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -117,7 +117,7 @@ class TestStorage(unittest.TestCase):
         if not validation.valid_directory('/tmp/etc'):
             # handle cases where this is not run under osg test framework
             os.mkdir('/tmp/etc')
-            os.chmod('/tmp/etc', 0777)
+            os.chmod('/tmp/etc', 0o777)
             self.assertTrue(settings.check_attributes(attributes))
             os.rmdir('/tmp/etc')
         else:
@@ -138,7 +138,7 @@ class TestStorage(unittest.TestCase):
         settings = storage.StorageConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
@@ -159,7 +159,7 @@ class TestStorage(unittest.TestCase):
         if not validation.valid_directory('/tmp/etc'):
             # handle cases where this is not run under osg test framework
             os.mkdir('/tmp/etc')
-            os.chmod('/tmp/etc', 0777)
+            os.chmod('/tmp/etc', 0o777)
             self.assertTrue(settings.check_attributes(attributes))
             os.rmdir('/tmp/etc')
         else:
@@ -180,7 +180,7 @@ class TestStorage(unittest.TestCase):
         settings = storage.StorageConfiguration(logger=global_logger)
         try:
             settings.parse_configuration(configuration)
-        except Exception, e:
+        except Exception as e:
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()

--- a/tests/test_subcluster.py
+++ b/tests/test_subcluster.py
@@ -3,6 +3,7 @@
 # pylint: disable=W0703
 # pylint: disable=R0904
 
+from __future__ import print_function
 import os
 import sys
 import unittest

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -34,7 +34,7 @@ class TestUtilities(unittest.TestCase):
                 self.assertEqual(open(attribute_file).read(),
                                  open(attribute_standard).read(),
                                  'Attribute files are not equal')
-            except Exception, ex:
+            except Exception as ex:
                 self.fail('Got exception while testing write_attribute_file' \
                           "functionality:\n%s" % ex)
         finally:


### PR DESCRIPTION
These are some safe changes to start making osg-configure Python 3-compatible.
Commands run:

    python-modernize -w -f lib2to3.fixes.fix_except scripts/osg-configure osg_configure/*/*.py tests/*.py
    python-modernize -w -f lib2to3.fixes.fix_numliterals scripts/osg-configure osg_configure/*/*.py tests/*.py
    python-modernize -w -f libmodernize.fixes.fix_print scripts/osg-configure osg_configure/*/*.py tests/*.py