### PR TITLE
Drop unused squid attributes

### DIFF
--- a/config/01-squid.ini
+++ b/config/01-squid.ini
@@ -11,15 +11,3 @@ enabled = True
 ; If you are using squid, specify the location of the squid server in the 
 ; location setting, this should be an url
 location = 
-
-; If you are using squid, use the policy setting to indicate which cache
-; replacement policy squid is using
-policy = DEFAULT
-
-; If you are using squid, use the cache_size setting to indicate which the 
-; size of the disk cache that squid is using
-cache_size = DEFAULT
-
-; If you are using squid, use the memory_size setting to indicate which the 
-; size of the memory cache that squid is using
-memory_size = DEFAULT

--- a/config/01-squid.ini
+++ b/config/01-squid.ini
@@ -9,5 +9,5 @@
 enabled = True
 
 ; If you are using squid, specify the location of the squid server in the 
-; location setting, this should be an url
+; location setting, this should be a URL
 location = 

--- a/osg_configure/configure_modules/squid.py
+++ b/osg_configure/configure_modules/squid.py
@@ -21,23 +21,7 @@ class SquidConfiguration(BaseConfiguration):
         self.options = {'location':
                             configfile.Option(name='location',
                                               default_value='None',
-                                              mapping='OSG_SQUID_LOCATION'),
-                        'policy':
-                            configfile.Option(name='policy',
-                                              required=configfile.Option.OPTIONAL,
-                                              mapping='OSG_SQUID_POLICY'),
-                        'cache_size':
-                            configfile.Option(name='cache_size',
-                                              required=configfile.Option.OPTIONAL,
-                                              default_value=0,
-                                              opt_type=int,
-                                              mapping='OSG_SQUID_CACHE_SIZE'),
-                        'memory_size':
-                            configfile.Option(name='memory_size',
-                                              required=configfile.Option.OPTIONAL,
-                                              default_value=0,
-                                              opt_type=int,
-                                              mapping='OSG_SQUID_MEM_CACHE')}
+                                              mapping='OSG_SQUID_LOCATION')}
         self.config_section = 'Squid'
         self.log('SquidConfiguration.__init__ completed')
 
@@ -60,7 +44,7 @@ class SquidConfiguration(BaseConfiguration):
             if not self.ignored and not self.enabled:
                 return True
 
-        self.get_options(configuration, ignore_options=['enabled'])
+        self.get_options(configuration, ignore_options=['enabled', 'policy', 'cache_size', 'memory_size'])
 
         if not (utilities.blank(self.options['location'].value) or
                         self.options['location'].value == 'None'):

--- a/tests/configs/squid/ignored.ini
+++ b/tests/configs/squid/ignored.ini
@@ -2,6 +2,3 @@
 [Squid]
 enabled = Ignore
 location = test.com
-policy = LRU
-cache_size = 2048
-memory_size = 256

--- a/tests/configs/squid/squid1.ini
+++ b/tests/configs/squid/squid1.ini
@@ -2,6 +2,3 @@
 [Squid]
 enabled = True
 location = test.com
-policy = LRU
-cache_size = 2048
-memory_size = 256

--- a/tests/configs/squid/squid_bad_cache.ini
+++ b/tests/configs/squid/squid_bad_cache.ini
@@ -1,7 +1,0 @@
-
-[Squid]
-enabled = True
-location = example.com
-policy = LRU
-cache_size = 2048a
-memory_size = 256

--- a/tests/configs/squid/squid_bad_host.ini
+++ b/tests/configs/squid/squid_bad_host.ini
@@ -2,6 +2,3 @@
 [Squid]
 enabled = True
 location = 4j92_~.393aD[
-policy = LRU
-cache_size = 2048
-memory_size = 256

--- a/tests/configs/squid/squid_bad_host2.ini
+++ b/tests/configs/squid/squid_bad_host2.ini
@@ -2,6 +2,3 @@
 [Squid]
 enabled = True
 location = http://my.host:3128
-policy = LRU
-cache_size = 2048
-memory_size = 256

--- a/tests/configs/squid/squid_bad_mem.ini
+++ b/tests/configs/squid/squid_bad_mem.ini
@@ -1,7 +1,0 @@
-
-[Squid]
-enabled = True
-location = example.com
-policy = LRU
-cache_size = 2048
-memory_size = 256a

--- a/tests/configs/squid/squid_bad_port.ini
+++ b/tests/configs/squid/squid_bad_port.ini
@@ -2,6 +2,3 @@
 [Squid]
 enabled = True
 location = example.org:f23
-policy = LRU
-cache_size = 2048
-memory_size = 256

--- a/tests/configs/squid/squid_blank_location.ini
+++ b/tests/configs/squid/squid_blank_location.ini
@@ -1,6 +1,3 @@
 [Squid]
 enabled = True
 location = 
-policy = LRU
-cache_size = 2048
-memory_size = 256

--- a/tests/configs/squid/squid_unavailable.ini
+++ b/tests/configs/squid/squid_unavailable.ini
@@ -1,6 +1,3 @@
 [Squid]
 enabled = True
 location = UNAVAILABLE
-policy = LRU
-cache_size = 2048
-memory_size = 256

--- a/tests/configs/squid/valid_settings.ini
+++ b/tests/configs/squid/valid_settings.ini
@@ -2,6 +2,3 @@
 [Squid]
 enabled = True
 location = test.com
-policy = LRU
-cache_size = 2048
-memory_size = 256

--- a/tests/test_squid.py
+++ b/tests/test_squid.py
@@ -51,10 +51,7 @@ class TestSquid(unittest.TestCase):
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
-        variables = {'OSG_SQUID_LOCATION': "test.com:3128",
-                     'OSG_SQUID_POLICY': 'LRU',
-                     'OSG_SQUID_CACHE_SIZE': '2048',
-                     'OSG_SQUID_MEM_CACHE': '256'}
+        variables = {'OSG_SQUID_LOCATION': "test.com:3128"}
         for var in variables:
             self.assertTrue(attributes.has_key(var),
                             "Attribute %s missing" % var)
@@ -79,10 +76,7 @@ class TestSquid(unittest.TestCase):
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
-        variables = {'OSG_SQUID_LOCATION': 'example.com:3128',
-                     'OSG_SQUID_POLICY': 'LRU',
-                     'OSG_SQUID_CACHE_SIZE': '2048',
-                     'OSG_SQUID_MEM_CACHE': '256'}
+        variables = {'OSG_SQUID_LOCATION': 'example.com:3128'}
         for var in variables:
             self.assertTrue(attributes.has_key(var),
                             "Attribute %s missing" % var)
@@ -131,13 +125,10 @@ class TestSquid(unittest.TestCase):
             self.fail("Received exception while parsing configuration: %s" % e)
 
         attributes = settings.get_attributes()
-        self.assertEqual(len(attributes), 4,
-                         "Ignored configuration should have 4 attributes")
+        self.assertEqual(len(attributes), 1,
+                         "Ignored configuration should have 1 attribute")
 
-        variables = {'OSG_SQUID_LOCATION': 'test.com:3128',
-                     'OSG_SQUID_POLICY': 'LRU',
-                     'OSG_SQUID_CACHE_SIZE': '2048',
-                     'OSG_SQUID_MEM_CACHE': '256'}
+        variables = {'OSG_SQUID_LOCATION': 'test.com:3128'}
         for var in variables:
             self.assertTrue(attributes.has_key(var),
                             "Attribute %s missing" % var)
@@ -162,38 +153,6 @@ class TestSquid(unittest.TestCase):
             self.assertRaises(exceptions.SettingError,
                               settings.parse_configuration,
                               configuration)
-
-    def testBadMemory(self):
-        """
-        Test the check_attributes function when memory size is not an integer
-        """
-
-        if not ce_installed():
-            return True
-        config_file = get_test_config("squid/squid_bad_mem.ini")
-        configuration = ConfigParser.SafeConfigParser()
-        configuration.read(config_file)
-
-        settings = squid.SquidConfiguration(logger=global_logger)
-        self.assertRaises(exceptions.SettingError,
-                          settings.parse_configuration,
-                          configuration)
-
-    def testBadCache(self):
-        """
-        Test the check_attributes function when cache size is not an integer
-        """
-
-        if not ce_installed():
-            return True
-        config_file = get_test_config("squid/squid_bad_cache.ini")
-        configuration = ConfigParser.SafeConfigParser()
-        configuration.read(config_file)
-
-        settings = squid.SquidConfiguration(logger=global_logger)
-        self.assertRaises(exceptions.SettingError,
-                          settings.parse_configuration,
-                          configuration)
 
     def testBadHost(self):
         """


### PR DESCRIPTION
Nothing uses them and they don't end up in the environment file.
(SOFTWARE-3152)