### PR TITLE
Allow skipping bosco_cluster (SOFTWARE-3730)

### DIFF
--- a/config/20-bosco.ini
+++ b/config/20-bosco.ini
@@ -25,5 +25,8 @@ batch = UNAVAILABLE
 ; remote cluster's login node.
 ssh_key = UNAVAILABLE
 
+; Run bosco_cluster, which makes changes to the remote host
+run_bosco_cluster = True
+
 ; (Optional) The maximum number of jobs to submit to the remote cluster, idle + running.
 max_jobs = 1000

--- a/config/20-bosco.ini
+++ b/config/20-bosco.ini
@@ -25,8 +25,12 @@ batch = UNAVAILABLE
 ; remote cluster's login node.
 ssh_key = UNAVAILABLE
 
-; Run bosco_cluster, which makes changes to the remote host
-run_bosco_cluster = True
+; Install the cluster via bosco_cluster -a, which makes changes to the remote host.
+; Possible values are:
+;   always: always install the cluster
+;   never: never install the cluster
+;   if_needed: install the cluster if it's not already installed (not in bosco's clusterlist)
+;install_cluster = if_needed
 
 ; (Optional) The maximum number of jobs to submit to the remote cluster, idle + running.
 max_jobs = 1000

--- a/osg_configure/configure_modules/bosco.py
+++ b/osg_configure/configure_modules/bosco.py
@@ -301,16 +301,16 @@ Host %(host)s
                         self.log("Entry found in clusterlist", level=logging.DEBUG)
                         return True
                 else:
-                    self.log("Unexpected exit code from bosco_cluster -l: %d" % returncode, level=logging.ERROR)
+                    self.log("bosco_cluster -l failed with unexpected exit code %d" % returncode, level=logging.ERROR)
                     self.log("stdout:\n%s" % stdout, level=logging.ERROR)
                     self.log("stderr:\n%s" % stderr, level=logging.ERROR)
                     return False
 
             # Step 2. Run bosco cluster to install the remote cluster
-            install_cmd = "bosco_cluster -a %(endpoint)s %(rms)s" % locals()
+            install_cmd = ["bosco_cluster", "-a", endpoint, rms]
 
-            self.log("Bosco command to execute: %s" % install_cmd)
-            process = subprocess.Popen(install_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True,
+            self.log("Bosco command to execute: %s" % install_cmd, level=logging.DEBUG)
+            process = subprocess.Popen(install_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                        preexec_fn=demote(user_uid, user_gid), env=env)
             stdout, stderr = process.communicate()
             returncode = process.returncode


### PR DESCRIPTION
This adds an option to disable running bosco_cluster, or only run it if it hasn't already been run (if there isn't already an entry for that endpoint+batch system in bosco's clusterlist).