### PR TITLE
Remove "classad" from requirements.txt:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 htcondor
-classad


### PR DESCRIPTION
It is not the classad library provided by the HTCondor Team; that comes from the `htcondor` package

There is another, conflicting package in PyPI named `classad` that does not have the same interface.