### PR TITLE
Add estimated_cpucount (SOFTWARE-6197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,15 +432,16 @@ Valid values for the **os** option are: `rhel6`, `rhel7`, `rhel8`, or `ubuntu18`
 
 The following attributes are optional:
 
-| Option              | Values Accepted      | Explanation                                                                                                                              |
-|---------------------|----------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| **cpucount**        | Positive Integer     | Number of cores that a job using this type of pilot can get.  Default `1`; ignored if **whole\_node** is `True`                          |
-| **ram\_mb**         | Positive Integer     | Maximum amount of memory (in MB) that a job using this type of pilot can get.  Default `2500`; ignored if **whole\_node** is `True`      |
-| **whole\_node**     | `True`, `False`      | Whether this type of pilot can use all the resources on a node.  Default `False`; **cpucount** and **ram\_mb** are ignored if this is `True` |
-| **gpucount**        | Non-negative Integer | The number of GPUs to request.  Default `0`                                                                                              |
-| **max\_wall\_time** | Positive Integer     | Maximum wall-clock time, in minutes, that a job is allowed to run on this resource.  Default `1440`, i.e. 24 hours                       |
-| **queue**           | String               | The queue or partition which jobs should be submitted to in order to run on this resource (see note).  Not set by default                |
-| **send\_tests**     | `True`, `False`      | Send test pilots.  Default `False`; set it to `True` for testing job routes or pilot types                                               |
+| Option              | Values Accepted      | Explanation                                                                                                                                                                                        |
+|---------------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **cpucount**        | Positive Integer     | Number of cores that a job using this type of pilot can get.  Default `1`; ignored if **whole\_node** is `True`                                                                                    |
+| **ram\_mb**         | Positive Integer     | Maximum amount of memory (in MB) that a job using this type of pilot can get.  Default `2500`; ignored if **whole\_node** is `True`                                                                |
+| **whole\_node**     | `True`, `False`      | Whether this type of pilot can use all the resources on a node.  Default `False`; **cpucount** and **ram\_mb** are ignored if this is `True`; **estimated\_cpucount** is ignored if this is `False` |
+| **estimated\_cpucount** | Positive Integer | The number of CPUs we expect on average when requesting a whole node.  Ignored if **whole\_node** is `False`                                                                                       |
+| **gpucount**        | Non-negative Integer | The number of GPUs to request.  Default `0`                                                                                                                                                        |
+| **max\_wall\_time** | Positive Integer     | Maximum wall-clock time, in minutes, that a job is allowed to run on this resource.  Default `1440`, i.e. 24 hours                                                                                 |
+| **queue**           | String               | The queue or partition which jobs should be submitted to in order to run on this resource (see note).  Not set by default                                                                          |
+| **send\_tests**     | `True`, `False`      | Send test pilots.  Default `False`; set it to `True` for testing job routes or pilot types                                                                                                         |
 
 **Note:** **queue** is equivalent to the HTCondor grid universe classad attribute **remote\_queue**.
 

--- a/config/35-pilot.ini
+++ b/config/35-pilot.ini
@@ -23,6 +23,8 @@
 ;ram_mb = 2500
 ;; This is a whole node pilot; cpucount and ram_mb are ignored if this is true.
 ;whole_node = false
+;; This is the number of CPUs available on a whole note pilot; this is ignored if whole_node is false.
+;estimated_cpucount = 8
 ;; The number of GPUs available
 ;gpucount = 0
 ;; The maximum number of pilots of this type that can be sent

--- a/osg_configure/modules/resourcecatalog.py
+++ b/osg_configure/modules/resourcecatalog.py
@@ -29,6 +29,7 @@ ATTRIBUTE_MAPPINGS = [
     RCAttribute("name", "Name", utilities.classad_quote),
     RCAttribute("cpus", "CPUs", int),
     RCAttribute("memory", "Memory", int),
+    RCAttribute("estimated_cpucount", "EstimatedCPUs", int),
     RCAttribute("allowed_vos", "AllowedVOs", _to_classad_list),
     RCAttribute("max_wall_time", "MaxWallTime", int),
     RCAttribute("queue", "Queue", utilities.classad_quote),
@@ -65,6 +66,7 @@ class RCEntry(object):
         self.os = kwargs.get('os', None)
         self.send_tests = kwargs.get('send_tests', None)
         self.is_pilot = kwargs.get('is_pilot', None)
+        self.estimated_cpucount = kwargs.get('estimated_cpucount', None)
 
     def get_requirements(self, attributes):
         if self.is_pilot:

--- a/osg_configure/modules/subcluster.py
+++ b/osg_configure/modules/subcluster.py
@@ -33,6 +33,7 @@ ENTRIES = {
     "subclusters":         (OPTIONAL, LIST),
     "vo_tag":              (OPTIONAL, STRING),
     # added for Pilots
+    "estimated_cpucount":  (OPTIONAL, POSITIVE_INT),
     "gpucount":            (OPTIONAL, POSITIVE_INT),
     "max_pilots":          (REQUIRED_FOR_PILOT, POSITIVE_INT),
     "os":                  (OPTIONAL, STRING),
@@ -72,6 +73,7 @@ ENTRY_RANGES = {
     'maxmemory': (512, 8388608),
     'cores_per_node': (1, 8192),
     'cpucount': (1, 8192),
+    'estimated_cpucount': (1, 8192),
 }
 
 CPUCOUNT_DEFAULT = 1
@@ -219,7 +221,7 @@ def rce_section_get_name(config: ConfigParser, section: str) -> Optional[str]:
     """
     m = re.search(r"(?i:subcluster|resource entry|pilot)\s+(.+)", section)
     if not m:
-        return
+        return None
     default_name = m.group(1)
     return config[section].get("name", default_name).strip()
 
@@ -235,6 +237,7 @@ class ResourceCatalog:  # forward declaration for type checking
 def resource_catalog_from_config(config: ConfigParser, default_allowed_vos: List[str] = None) -> ResourceCatalog:
     """
     Create a ResourceCatalog from the subcluster entries in a config
+    :param config: The config to pull the subcluster information from
     :param default_allowed_vos: The allowed_vos to use if the user specified "*"
     """
     logger = logging.getLogger(__name__)
@@ -321,9 +324,12 @@ def resource_catalog_from_config(config: ConfigParser, default_allowed_vos: List
         if is_pilot(section):
             rcentry.max_pilots = safeget("max_pilots")
             rcentry.whole_node = safegetbool("whole_node", False)
+            rcentry.estimated_cpucount = safeget("estimated_cpucount")
             if rcentry.whole_node:
                 rcentry.cpus = None
                 rcentry.memory = None
+            else:
+                rcentry.estimated_cpucount = None
             rcentry.require_singularity = safegetbool("require_singularity", True)
             rcentry.os = safeget("os")
             rcentry.send_tests = safegetbool("send_tests", True)

--- a/tests/configs/subcluster/pilots_example.ini
+++ b/tests/configs/subcluster/pilots_example.ini
@@ -13,6 +13,13 @@ max_wall_time = 1440
 allowed_vos = atlas
 max_pilots = 1000
 
+[Pilot WholeNode_with_estimated_cpucount]
+whole_node = true
+estimated_cpucount = 32
+max_wall_time = 1440
+allowed_vos = atlas
+max_pilots = 1000
+
 [Pilot default]
 ram_mb = 32768
 os = rhel6

--- a/tests/test_resourcecatalog.py
+++ b/tests/test_resourcecatalog.py
@@ -327,6 +327,17 @@ os = rhel8
     WholeNode = True; \
   ], \
   [ \
+    AllowedVOs = { "atlas" }; \
+    EstimatedCPUs = 32; \
+    IsPilotEntry = True; \
+    MaxPilots = 1000; \
+    MaxWallTime = 1440; \
+    Name = "WholeNode_with_estimated_cpucount"; \
+    RequireSingularity = True; \
+    SendTests = True; \
+    WholeNode = True; \
+  ], \
+  [ \
     AllowedVOs = { "osg", "cms" }; \
     CPUs = 8; \
     IsPilotEntry = True; \


### PR DESCRIPTION
Adds the "estimated_cpucount" option to the `[Pilot]` sections of the config file, which result in an `EstimatedCPUs` attribute in the resulting `OSG_ResourceCatalog` ads. The option is only used if `whole_node` is set, and is ignored otherwise.

https://opensciencegrid.atlassian.net/browse/SOFTWARE-6197