### PR TITLE
Migrate to htcondor2 and classad2 (SOFTWARE-6239)

### DIFF
--- a/osg_configure/configure_modules/infoservices.py
+++ b/osg_configure/configure_modules/infoservices.py
@@ -25,9 +25,9 @@ BAN_MAPFILE = '/etc/grid-security/ban-mapfile'
 
 
 try:
-    import classad
+    import classad2 as classad
 except ImportError:
-    classad = None
+    import classad
 
 
 class InfoServicesConfiguration(BaseConfiguration):
@@ -144,19 +144,12 @@ class InfoServicesConfiguration(BaseConfiguration):
             return True
 
         if self.ce_collector_required_rpms_installed and self.htcondor_gateway_enabled:
-            if classad is None:
-                self.log("Cannot configure HTCondor CE info services: unable to import HTCondor Python bindings."
-                         "\nEnsure the 'classad' Python module is installed and accessible to Python scripts."
-                         "\nIf using HTCondor from RPMs, install the 'python3-condor' RPM."
-                         "\nIf not, you may need to add the directory containing the Python bindings to PYTHONPATH."
-                         "\nHTCondor version must be at least 8.2.0.", level=logging.WARNING)
-            else:
-                try:
-                    self.ce_attributes_str = ce_attributes.get_ce_attributes_str(self.configuration)
-                except exceptions.SettingError as err:
-                    self.log("Error in info services configuration: %s" % err, level=logging.ERROR)
-                    return False
-                self._configure_ce_collector()
+            try:
+                self.ce_attributes_str = ce_attributes.get_ce_attributes_str(self.configuration)
+            except exceptions.SettingError as err:
+                self.log("Error in info services configuration: %s" % err, level=logging.ERROR)
+                return False
+            self._configure_ce_collector()
 
         self.log("InfoServicesConfiguration.configure completed")
         return True

--- a/osg_configure/modules/resourcecatalog.py
+++ b/osg_configure/modules/resourcecatalog.py
@@ -1,4 +1,7 @@
-import classad
+try:
+    import classad2 as classad
+except ImportError:
+    import classad
 import logging
 from collections import namedtuple
 from . import utilities

--- a/osg_configure/modules/utilities.py
+++ b/osg_configure/modules/utilities.py
@@ -563,7 +563,10 @@ def config_safe_getboolean(configuration: ConfigParser, section: str, option: st
 
 # Import classad here because it might not be available for e.g. SEs
 def classad_quote(input_value):
-    import classad
+    try:
+        import classad2 as classad
+    except ImportError:
+        import classad
     return classad.quote(str(input_value))
 
 


### PR DESCRIPTION
Note: the name of the PyPI package does not change.

Also drop error message from info services if we don't have Python bindings since it's no longer possible to install osg-configure-infoservices without them.