### PR TITLE
Fix Python 3.12 (EL10) incompatibilities

### DIFF
--- a/osg_configure/configure_modules/bosco.py
+++ b/osg_configure/configure_modules/bosco.py
@@ -182,6 +182,7 @@ class BoscoConfiguration(JobManagerConfiguration):
             return True
         
         # Do all the things here!
+        # noinspection PyDeprecation
         self.bosco_cluster = shutil.which("condor_remote_cluster") or shutil.which("bosco_cluster")
 
         if not self.bosco_cluster and self.opt_val("install_cluster") != "never":
@@ -390,8 +391,8 @@ Host %(endpoint_host)s
         
         if not os.path.exists(config_path):
             return False
-        
-        host_re = re.compile("^\s*Host\s+%s\s*$" % host)
+
+        host_re = re.compile(r"^\s*Host\s+%s\s*$" % host)
 
         with open(config_path, "r", encoding="latin-1") as f:
             for line in f:

--- a/osg_configure/modules/configfile.py
+++ b/osg_configure/modules/configfile.py
@@ -5,6 +5,8 @@ import configparser
 import os
 import sys
 
+from typing import Union
+
 from osg_configure.modules import exceptions
 from osg_configure.modules import utilities
 from osg_configure.modules import validation
@@ -176,6 +178,8 @@ class Option:
     MANDATORY = 1
     OPTIONAL = 2
     MANDATORY_ON_CE = 3
+
+    value: Union[str, int, float, None]
 
     def __init__(self, **kwargs):
         """

--- a/osg_configure/modules/configfile.py
+++ b/osg_configure/modules/configfile.py
@@ -44,7 +44,7 @@ def read_config_files(**kwargs):
             sys.stderr.write("Error found in %s\n" % filename)
             sys.exit(1)
     try:
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         if case_sensitive:
             config.optionxform = str
     except configparser.Error as e:
@@ -80,8 +80,8 @@ def get_option_location(option, section, **kwargs):
     file_list.reverse()
     for fn in file_list:
         try:
-            config = configparser.SafeConfigParser()
-            config.readfp(open(fn, "r", encoding="latin-1"))
+            config = configparser.RawConfigParser()
+            config.read_file(open(fn, "r", encoding="latin-1"), source=fn)
             if config.has_option(section, option):
                 return fn
         except configparser.Error as e:

--- a/osg_configure/modules/reversevomap.py
+++ b/osg_configure/modules/reversevomap.py
@@ -107,7 +107,7 @@ def get_vos(mappings):
 
     :return: Set of VOs
     """
-    regex = re.compile("^/(\w+)/")
+    regex = re.compile(r"^/(\w+)/")
     patterns = (m.pattern for m in mappings)
     matches = filter(None, (regex.match(p) for p in patterns))
     vo_groups = set(m.group(1).lower() for m in matches)

--- a/osg_configure/modules/utilities.py
+++ b/osg_configure/modules/utilities.py
@@ -3,7 +3,6 @@ import errno
 import glob
 import logging
 import os
-import platform
 import re
 import socket
 import stat
@@ -524,15 +523,6 @@ def make_directory(dir_name, perms=0o755, uid=None, gid=None):
         return True
     except IOError:
         return False
-
-
-def get_os_version():
-    """
-    Get and return OS major version
-    """
-    version = platform.dist()[1]
-    version_list = [int(x) for x in version.split('.')]
-    return version_list
 
 
 def config_safe_get(configuration: ConfigParser, section: str, option: str, default=None) -> str:

--- a/osg_configure/modules/validation.py
+++ b/osg_configure/modules/validation.py
@@ -265,7 +265,7 @@ def valid_ini_file(filename):
     file_buffer.write(temp)
     file_buffer.seek(0)
     try:
-        configuration.readfp(file_buffer)  # TODO readfp is deprecated
+        configuration.read_file(file_buffer)
     except ParsingError as e:
         print("Error while parsing: %s\n%s" % (filename, e), file=sys.stderr)
         print("Lines with options should not start with a space", file=sys.stderr)

--- a/tests/test_condor.py
+++ b/tests/test_condor.py
@@ -40,7 +40,7 @@ class TestCondor(unittest.TestCase):
         """
 
         config_file = get_test_config("condor/condor1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = condor.CondorConfiguration(logger=global_logger)
@@ -68,7 +68,7 @@ class TestCondor(unittest.TestCase):
         """
 
         config_file = get_test_config("condor/condor_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = condor.CondorConfiguration(logger=global_logger)
@@ -87,7 +87,7 @@ class TestCondor(unittest.TestCase):
         """
 
         config_file = get_test_config("condor/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = condor.CondorConfiguration(logger=global_logger)
@@ -106,7 +106,7 @@ class TestCondor(unittest.TestCase):
         """
 
         config_file = get_test_config("condor/condor_defaults1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
 
@@ -155,7 +155,7 @@ class TestCondor(unittest.TestCase):
         # check to make sure that config values take precedence over
         # environment variables
         config_file = get_test_config("condor/condor1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
         os.environ['CONDOR_LOCATION'] = '/my/condor1'
         settings = condor.CondorConfiguration(logger=global_logger)
@@ -178,7 +178,7 @@ class TestCondor(unittest.TestCase):
 
         # check to see if jobmanager home values get used in preference to other values
         config_file = get_test_config("condor/condor_defaults2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
         os.environ['CONDOR_LOCATION'] = '/my/condor1'
         settings = condor.CondorConfiguration(logger=global_logger)
@@ -205,7 +205,7 @@ class TestCondor(unittest.TestCase):
         """
 
         config_file = get_test_config("condor/missing_location.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = condor.CondorConfiguration(logger=global_logger)
@@ -227,7 +227,7 @@ class TestCondor(unittest.TestCase):
         for filename in [get_test_config("condor/missing_config1.ini"),
                          get_test_config("condor/missing_config2.ini")]:
             config_file = os.path.abspath(filename)
-            configuration = configparser.SafeConfigParser()
+            configuration = configparser.ConfigParser()
             configuration.read(config_file)
 
             settings = condor.CondorConfiguration(logger=global_logger)
@@ -247,7 +247,7 @@ class TestCondor(unittest.TestCase):
         """
 
         config_file = get_test_config("condor/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = condor.CondorConfiguration(logger=global_logger)
@@ -266,7 +266,7 @@ class TestCondor(unittest.TestCase):
         """
 
         config_file = get_test_config("condor/check_ok2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = condor.CondorConfiguration(logger=global_logger)
@@ -285,7 +285,7 @@ class TestCondor(unittest.TestCase):
         """
 
         config_file = get_test_config("condor/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = condor.CondorConfiguration(logger=global_logger)
@@ -300,7 +300,7 @@ class TestCondor(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
         config_file = get_test_config("condor/condor_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = condor.CondorConfiguration(logger=global_logger)

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -32,7 +32,7 @@ class TestGateway(unittest.TestCase):
         """
 
         config_file = get_test_config("gateway/gateway_default.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gateway.GatewayConfiguration(logger=global_logger)

--- a/tests/test_gratia.py
+++ b/tests/test_gratia.py
@@ -41,7 +41,7 @@ class TestGratia(unittest.TestCase):
         """
 
         config_file = get_test_config("gratia/gratia.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -71,7 +71,7 @@ class TestGratia(unittest.TestCase):
             return
 
         config_file = get_test_config("gratia/itb_default.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -100,7 +100,7 @@ class TestGratia(unittest.TestCase):
             return
 
         config_file = get_test_config("gratia/prod_default.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -129,7 +129,7 @@ class TestGratia(unittest.TestCase):
         if not gratia.requirements_are_installed():
             return
         config_file = get_test_config("gratia/itb_default2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -149,7 +149,7 @@ class TestGratia(unittest.TestCase):
                              "expected %s" % (var, options[var].value, variables[var]))
 
         config_file = get_test_config("gratia/itb_default3.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -178,7 +178,7 @@ class TestGratia(unittest.TestCase):
         if not gratia.requirements_are_installed():
             return
         config_file = get_test_config("gratia/prod_default2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -203,7 +203,7 @@ class TestGratia(unittest.TestCase):
         """
 
         config_file = get_test_config("gratia/disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -222,7 +222,7 @@ class TestGratia(unittest.TestCase):
         """
 
         config_file = get_test_config("gratia/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -242,7 +242,7 @@ class TestGratia(unittest.TestCase):
         """
 
         config_file = get_test_config("gratia/invalid_probe2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -261,7 +261,7 @@ class TestGratia(unittest.TestCase):
         """
 
         config_file = get_test_config("gratia/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -282,7 +282,7 @@ class TestGratia(unittest.TestCase):
         """
 
         config_file = get_test_config("gratia/disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -300,7 +300,7 @@ class TestGratia(unittest.TestCase):
         Test the ITB defaults and make sure that they are valid
         """
         config_file = get_test_config("gratia/itb_default.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -323,7 +323,7 @@ class TestGratia(unittest.TestCase):
         Test the production defaults and make sure that they are valid
         """
         config_file = get_test_config("gratia/prod_default.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -344,7 +344,7 @@ class TestGratia(unittest.TestCase):
         gratia section is missing
         """
         config_file = get_test_config("gratia/itb_default2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -363,7 +363,7 @@ class TestGratia(unittest.TestCase):
         gratia section is missing
         """
         config_file = get_test_config("gratia/prod_default2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -382,7 +382,7 @@ class TestGratia(unittest.TestCase):
         """
 
         config_file = get_test_config("gratia/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)
@@ -397,7 +397,7 @@ class TestGratia(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
         config_file = get_test_config("gratia/disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = gratia.GratiaConfiguration(logger=global_logger)

--- a/tests/test_info_services.py
+++ b/tests/test_info_services.py
@@ -17,13 +17,11 @@ import logging
 pathname = os.path.realpath('../')
 sys.path.insert(0, pathname)
 
-from osg_configure.modules import exceptions
 try:
     from osg_configure.configure_modules import infoservices
 except ImportError:
     infoservices = None
     print("infoservices not found -- skipping infoservices tests")
-from osg_configure.modules import utilities
 from osg_configure.modules.utilities import get_test_config
 
 global_logger = logging.getLogger(__name__)
@@ -48,7 +46,7 @@ class TestInfoServices(unittest.TestCase):
 
         if not infoservices: return
         config_file = get_test_config("infoservices/disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
@@ -64,7 +62,7 @@ class TestInfoServices(unittest.TestCase):
 
         if not infoservices: return
         config_file = get_test_config("infoservices/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
@@ -80,7 +78,7 @@ class TestInfoServices(unittest.TestCase):
 
         if not infoservices: return
         config_file = get_test_config("infoservices/disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
@@ -101,7 +99,7 @@ class TestInfoServices(unittest.TestCase):
 
         if not infoservices: return
         config_file = get_test_config("infoservices/itb_defaults2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
@@ -122,7 +120,7 @@ class TestInfoServices(unittest.TestCase):
 
         if not infoservices: return
         config_file = get_test_config("infoservices/prod_defaults2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)
@@ -142,7 +140,7 @@ class TestInfoServices(unittest.TestCase):
 
         if not infoservices: return
         config_file = get_test_config("infoservices/infoservices.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = infoservices.InfoServicesConfiguration(logger=global_logger)

--- a/tests/test_local_settings.py
+++ b/tests/test_local_settings.py
@@ -40,7 +40,7 @@ class TestLocalSettings(unittest.TestCase):
         """
 
         config_file = get_test_config("localsettings/local_settings1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.optionxform = str
         configuration.read(config_file)
 
@@ -64,7 +64,7 @@ class TestLocalSettings(unittest.TestCase):
 
     def testBogusVarName(self):
         config_file = get_test_config("localsettings/bogusvarname.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.optionxform = str
         configuration.read(config_file)
 
@@ -76,7 +76,7 @@ class TestLocalSettings(unittest.TestCase):
 
     def testBogusQuote(self):
         config_file = get_test_config("localsettings/bogusquote.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.optionxform = str
         configuration.read(config_file)
 

--- a/tests/test_lsf.py
+++ b/tests/test_lsf.py
@@ -40,7 +40,7 @@ class TestLSF(unittest.TestCase):
         """
 
         config_file = get_test_config("lsf/lsf1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = lsf.LSFConfiguration(logger=global_logger)
@@ -67,7 +67,7 @@ class TestLSF(unittest.TestCase):
         """
 
         config_file = get_test_config("lsf/lsf_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = lsf.LSFConfiguration(logger=global_logger)
@@ -87,7 +87,7 @@ class TestLSF(unittest.TestCase):
         """
 
         config_file = get_test_config("lsf/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = lsf.LSFConfiguration(logger=global_logger)
@@ -106,7 +106,7 @@ class TestLSF(unittest.TestCase):
         Test the check_attributes function to see if it catches missing LSF location
         """
         config_file = get_test_config("lsf/missing_location.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = lsf.LSFConfiguration(logger=global_logger)
@@ -124,7 +124,7 @@ class TestLSF(unittest.TestCase):
         Test the check_attributes function to see if it catches missing LSF profile
         """
         config_file = get_test_config("lsf/missing_profile.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = lsf.LSFConfiguration(logger=global_logger)
@@ -137,7 +137,7 @@ class TestLSF(unittest.TestCase):
         Test the check_attributes function to see if it works on valid settings
         """
         config_file = get_test_config("lsf/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = lsf.LSFConfiguration(logger=global_logger)
@@ -155,7 +155,7 @@ class TestLSF(unittest.TestCase):
         Test the check_attributes function to see if it works on valid settings
         """
         config_file = get_test_config("lsf/check_ok2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = lsf.LSFConfiguration(logger=global_logger)
@@ -174,7 +174,7 @@ class TestLSF(unittest.TestCase):
         """
 
         config_file = get_test_config("lsf/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = lsf.LSFConfiguration(logger=global_logger)
@@ -189,7 +189,7 @@ class TestLSF(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
         config_file = get_test_config("lsf/lsf_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = lsf.LSFConfiguration(logger=global_logger)

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -16,16 +16,8 @@ sys.path.insert(0, pathname)
 from osg_configure.configure_modules import pbs
 from osg_configure.modules.utilities import get_test_config
 
-# NullHandler is only available in Python 2.7+
-try:
-    NullHandler = logging.NullHandler
-except AttributeError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
 global_logger = logging.getLogger(__name__)
-global_logger.addHandler(NullHandler())
+global_logger.addHandler(logging.NullHandler())
 
 
 class TestPBS(unittest.TestCase):
@@ -39,7 +31,7 @@ class TestPBS(unittest.TestCase):
         """
 
         config_file = get_test_config("pbs/pbs1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = pbs.PBSConfiguration(logger=global_logger)
@@ -66,7 +58,7 @@ class TestPBS(unittest.TestCase):
         """
 
         config_file = get_test_config("pbs/pbs_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = pbs.PBSConfiguration(logger=global_logger)
@@ -85,7 +77,7 @@ class TestPBS(unittest.TestCase):
         """
 
         config_file = get_test_config("pbs/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = pbs.PBSConfiguration(logger=global_logger)
@@ -103,7 +95,7 @@ class TestPBS(unittest.TestCase):
         Test the check_attributes function to see if it catches missing pbs location
         """
         config_file = get_test_config("pbs/missing_location.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = pbs.PBSConfiguration(logger=global_logger)
@@ -121,7 +113,7 @@ class TestPBS(unittest.TestCase):
         Test the check_attributes function to see if it works on valid settings
         """
         config_file = get_test_config("pbs/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = pbs.PBSConfiguration(logger=global_logger)
@@ -139,7 +131,7 @@ class TestPBS(unittest.TestCase):
         Test the check_attributes function to see if it works on valid settings
         """
         config_file = get_test_config("pbs/check_ok2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = pbs.PBSConfiguration(logger=global_logger)
@@ -158,7 +150,7 @@ class TestPBS(unittest.TestCase):
         """
 
         config_file = get_test_config("pbs/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = pbs.PBSConfiguration(logger=global_logger)
@@ -173,7 +165,7 @@ class TestPBS(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
         config_file = get_test_config("pbs/pbs_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = pbs.PBSConfiguration(logger=global_logger)
@@ -188,7 +180,7 @@ class TestPBS(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
         config_file = get_test_config("pbs/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = pbs.PBSConfiguration(logger=global_logger)

--- a/tests/test_resourcecatalog.py
+++ b/tests/test_resourcecatalog.py
@@ -105,7 +105,7 @@ class TestResourceCatalog(unittest.TestCase):
 }""")
 
     def testFull(self):
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config_string = r"""
 [Subcluster Valid]
 name = red.unl.edu
@@ -139,7 +139,7 @@ allowed_vos = osg, atlas
     def testResourceEntry(self):
         # Test using the "Resource Entry" section name instead of "Subcluster"
         # and also using some of the attributes ATLAS requested
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config_string = r"""
 [Resource Entry Valid]
 name = red.unl.edu
@@ -166,7 +166,7 @@ allowed_vos = osg, atlas
 }""")
 
     def testResourceEntryWithSubclusters(self):
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config_file = get_test_config("subcluster/resourceentry_and_sc.ini")
         config.read(config_file)
         self.assertDoesNotRaise(exceptions.SettingError, subcluster.resource_catalog_from_config, config)
@@ -179,7 +179,7 @@ allowed_vos = osg, atlas
                                 "subcluster/resourceentry_missing_memory.ini",
                                 "subcluster/resourceentry_missing_queue.ini",
                                 "subcluster/resourceentry_missing_sc.ini"]:
-            config = configparser.SafeConfigParser()
+            config = configparser.ConfigParser()
             config_file = get_test_config(config_filename)
             config.read(config_file)
             try:
@@ -189,7 +189,7 @@ allowed_vos = osg, atlas
                 raise
 
     def testFullWithExtraTransforms(self):
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config_string = r"""
 [Subcluster Test]
 name = glow.chtc.wisc.edu
@@ -261,7 +261,7 @@ allowed_vos = osg, atlas
         self.assertLongStringEqual(actual_string, expected_string)
 
     def testPilot(self):
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config_string = r"""
 [Pilot glow.chtc.wisc.edu]
 name = glow.chtc.wisc.edu
@@ -298,7 +298,7 @@ os = rhel8
         self.assertLongStringEqual(actual_string, expected_string)
 
     def testPilotExample(self):
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/pilots_example.ini")
         config_parser.read(config_file)
         expected_string = r"""OSG_ResourceCatalog = { \

--- a/tests/test_sge.py
+++ b/tests/test_sge.py
@@ -17,16 +17,8 @@ from osg_configure.modules import exceptions
 from osg_configure.configure_modules import sge
 from osg_configure.modules.utilities import get_test_config
 
-# NullHandler is only available in Python 2.7+
-try:
-    NullHandler = logging.NullHandler
-except AttributeError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
 global_logger = logging.getLogger(__name__)
-global_logger.addHandler(NullHandler())
+global_logger.addHandler(logging.NullHandler())
 
 
 class TestSGE(unittest.TestCase):
@@ -40,7 +32,7 @@ class TestSGE(unittest.TestCase):
         """
 
         config_file = get_test_config("sge/sge1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = sge.SGEConfiguration(logger=global_logger)
@@ -69,7 +61,7 @@ class TestSGE(unittest.TestCase):
         """
 
         config_file = get_test_config("sge/sge_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = sge.SGEConfiguration(logger=global_logger)
@@ -88,7 +80,7 @@ class TestSGE(unittest.TestCase):
         """
 
         config_file = get_test_config("sge/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = sge.SGEConfiguration(logger=global_logger)
@@ -111,7 +103,7 @@ class TestSGE(unittest.TestCase):
                      'sge_bin_location']
         for option in mandatory:
             config_file = get_test_config("sge/sge1.ini")
-            configuration = configparser.SafeConfigParser()
+            configuration = configparser.ConfigParser()
             configuration.read(config_file)
             configuration.remove_option('SGE', option)
 
@@ -126,7 +118,7 @@ class TestSGE(unittest.TestCase):
         """
 
         config_file = get_test_config("sge/missing_root.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = sge.SGEConfiguration(logger=global_logger)
@@ -145,7 +137,7 @@ class TestSGE(unittest.TestCase):
         """
 
         config_file = get_test_config("sge/missing_cell.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = sge.SGEConfiguration(logger=global_logger)
@@ -164,7 +156,7 @@ class TestSGE(unittest.TestCase):
         """
 
         config_file = get_test_config("sge/missing_config.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = sge.SGEConfiguration(logger=global_logger)
@@ -183,7 +175,7 @@ class TestSGE(unittest.TestCase):
         """
 
         config_file = get_test_config("sge/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
         root = os.path.join(config_file[:-16], 'test_files')
         configuration.set('SGE', 'sge_root', root)
@@ -204,7 +196,7 @@ class TestSGE(unittest.TestCase):
         """
 
         config_file = get_test_config("sge/check_ok2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
         root = os.path.join(config_file[:-17], 'test_files')
         configuration.set('SGE', 'sge_root', root)
@@ -225,7 +217,7 @@ class TestSGE(unittest.TestCase):
         """
 
         config_file = get_test_config("sge/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = sge.SGEConfiguration(logger=global_logger)
@@ -240,7 +232,7 @@ class TestSGE(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
         config_file = get_test_config("sge/sge_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = sge.SGEConfiguration(logger=global_logger)
@@ -255,7 +247,7 @@ class TestSGE(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
         config_file = get_test_config("sge/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = sge.SGEConfiguration(logger=global_logger)

--- a/tests/test_siteattributes.py
+++ b/tests/test_siteattributes.py
@@ -17,16 +17,8 @@ from osg_configure.modules import exceptions
 from osg_configure.configure_modules import siteinformation
 from osg_configure.modules.utilities import get_test_config, ce_installed
 
-# NullHandler is only available in Python 2.7+
-try:
-    NullHandler = logging.NullHandler
-except AttributeError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
 global_logger = logging.getLogger(__name__)
-global_logger.addHandler(NullHandler())
+global_logger.addHandler(logging.NullHandler())
 
 
 class TestSiteAttributes(unittest.TestCase):
@@ -40,7 +32,7 @@ class TestSiteAttributes(unittest.TestCase):
         """
 
         config_file = get_test_config("siteattributes/siteattributes1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = siteinformation.SiteInformation(logger=global_logger)
@@ -68,7 +60,7 @@ class TestSiteAttributes(unittest.TestCase):
         """
 
         config_file = get_test_config("siteattributes/siteattributes2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = siteinformation.SiteInformation(logger=global_logger)
@@ -96,7 +88,7 @@ class TestSiteAttributes(unittest.TestCase):
         """
 
         config_file = get_test_config("siteattributes/siteattributes3.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = siteinformation.SiteInformation(logger=global_logger)
@@ -126,7 +118,7 @@ class TestSiteAttributes(unittest.TestCase):
         Test the parsing when attributes are missing, should get exceptions
         """
         config_file = get_test_config("siteattributes/siteattributes2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = siteinformation.SiteInformation(logger=global_logger)
@@ -143,7 +135,7 @@ class TestSiteAttributes(unittest.TestCase):
             mandatory += mandatory_on_ce
         for option in mandatory:
             config_file = get_test_config("siteattributes/siteattributes1.ini")
-            configuration = configparser.SafeConfigParser()
+            configuration = configparser.ConfigParser()
             configuration.read(config_file)
             configuration.remove_option('Site Information', option)
 
@@ -159,7 +151,7 @@ class TestSiteAttributes(unittest.TestCase):
 
         config_file = get_test_config("siteattributes/" \
                                       "invalid_hostname.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = siteinformation.SiteInformation(logger=global_logger)
@@ -178,7 +170,7 @@ class TestSiteAttributes(unittest.TestCase):
         """
 
         config_file = get_test_config("siteattributes/valid_settings.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = siteinformation.SiteInformation(logger=global_logger)
@@ -197,7 +189,7 @@ class TestSiteAttributes(unittest.TestCase):
         """
 
         config_file = get_test_config("siteattributes/siteattributes3.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = siteinformation.SiteInformation(logger=global_logger)

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -16,16 +16,8 @@ sys.path.insert(0, pathname)
 from osg_configure.configure_modules import slurm
 from osg_configure.modules.utilities import get_test_config
 
-# NullHandler is only available in Python 2.7+
-try:
-    NullHandler = logging.NullHandler
-except AttributeError:
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
 global_logger = logging.getLogger(__name__)
-global_logger.addHandler(NullHandler())
+global_logger.addHandler(logging.NullHandler())
 
 
 class TestSlurm(unittest.TestCase):
@@ -39,7 +31,7 @@ class TestSlurm(unittest.TestCase):
         """
 
         config_file = get_test_config("slurm/slurm1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = slurm.SlurmConfiguration(logger=global_logger)
@@ -66,7 +58,7 @@ class TestSlurm(unittest.TestCase):
         """
 
         config_file = get_test_config("slurm/slurm_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = slurm.SlurmConfiguration(logger=global_logger)
@@ -85,7 +77,7 @@ class TestSlurm(unittest.TestCase):
         """
 
         config_file = get_test_config("slurm/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = slurm.SlurmConfiguration(logger=global_logger)
@@ -103,7 +95,7 @@ class TestSlurm(unittest.TestCase):
         Test the check_attributes function to see if it catches missing pbs location
         """
         config_file = get_test_config("slurm/missing_location.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = slurm.SlurmConfiguration(logger=global_logger)
@@ -121,7 +113,7 @@ class TestSlurm(unittest.TestCase):
         Test the check_attributes function to see if it works on valid settings
         """
         config_file = get_test_config("slurm/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = slurm.SlurmConfiguration(logger=global_logger)
@@ -139,7 +131,7 @@ class TestSlurm(unittest.TestCase):
         Test the check_attributes function to see if it works on valid settings
         """
         config_file = get_test_config("slurm/check_ok2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = slurm.SlurmConfiguration(logger=global_logger)
@@ -158,7 +150,7 @@ class TestSlurm(unittest.TestCase):
         """
 
         config_file = get_test_config("slurm/check_ok.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = slurm.SlurmConfiguration(logger=global_logger)
@@ -174,7 +166,7 @@ class TestSlurm(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
         config_file = get_test_config("slurm/slurm_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = slurm.SlurmConfiguration(logger=global_logger)
@@ -189,7 +181,7 @@ class TestSlurm(unittest.TestCase):
                          "got %s but expected %s" % (services, expected_services))
 
         config_file = get_test_config("slurm/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = slurm.SlurmConfiguration(logger=global_logger)

--- a/tests/test_squid.py
+++ b/tests/test_squid.py
@@ -33,7 +33,7 @@ class TestSquid(unittest.TestCase):
         """
 
         config_file = get_test_config("squid/squid1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -58,7 +58,7 @@ class TestSquid(unittest.TestCase):
         """
 
         config_file = get_test_config("squid/squid2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -83,7 +83,7 @@ class TestSquid(unittest.TestCase):
         """
 
         config_file = get_test_config("squid/squid_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -107,7 +107,7 @@ class TestSquid(unittest.TestCase):
         """
 
         config_file = get_test_config("squid/ignored.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -137,7 +137,7 @@ class TestSquid(unittest.TestCase):
         mandatory = ['location']
         for option in mandatory:
             config_file = get_test_config("squid/squid1.ini")
-            configuration = configparser.SafeConfigParser()
+            configuration = configparser.ConfigParser()
             configuration.read(config_file)
             configuration.remove_option('Squid', option)
 
@@ -155,7 +155,7 @@ class TestSquid(unittest.TestCase):
         if not ce_installed():
             return True
         config_file = get_test_config("squid/squid_bad_host.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -169,7 +169,7 @@ class TestSquid(unittest.TestCase):
                          "Did not notice invalid host")
 
         config_file = get_test_config("squid/squid_bad_host2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -191,7 +191,7 @@ class TestSquid(unittest.TestCase):
         if not ce_installed():
             return True
         config_file = get_test_config("squid/squid_bad_port.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -212,7 +212,7 @@ class TestSquid(unittest.TestCase):
         if not ce_installed():
             return True
         config_file = get_test_config("squid/valid_settings.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -232,7 +232,7 @@ class TestSquid(unittest.TestCase):
         """
 
         config_file = get_test_config("squid/squid_disabled.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -254,7 +254,7 @@ class TestSquid(unittest.TestCase):
         if not ce_installed():
             return True
         config_file = get_test_config("squid/squid_blank_location.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)
@@ -274,7 +274,7 @@ class TestSquid(unittest.TestCase):
         """
 
         config_file = get_test_config("squid/squid_unavailable.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = squid.SquidConfiguration(logger=global_logger)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -38,7 +38,7 @@ class TestStorage(unittest.TestCase):
             return
 
         config_file = get_test_config("storage/storage1.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = storage.StorageConfiguration(logger=global_logger)
@@ -79,7 +79,7 @@ class TestStorage(unittest.TestCase):
         if not utilities.ce_installed():
             return
         config_file = get_test_config("storage/storage2.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = storage.StorageConfiguration(logger=global_logger)
@@ -120,7 +120,7 @@ class TestStorage(unittest.TestCase):
         if not utilities.ce_installed():
             return
         config_file = get_test_config("storage/storage3.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = storage.StorageConfiguration(logger=global_logger)
@@ -160,7 +160,7 @@ class TestStorage(unittest.TestCase):
         if not utilities.ce_installed():
             return
         config_file = get_test_config("storage/oasis.ini")
-        configuration = configparser.SafeConfigParser()
+        configuration = configparser.ConfigParser()
         configuration.read(config_file)
 
         settings = storage.StorageConfiguration(logger=global_logger)

--- a/tests/test_subcluster.py
+++ b/tests/test_subcluster.py
@@ -39,7 +39,7 @@ class TestSubcluster(unittest.TestCase):
         """
         Make sure that we have failures when there is no configured SC.
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/red-missing-sc.ini")
         config_parser.read(config_file)
         self.assertFalse(subcluster.check_config(config_parser), msg="Did not properly detect a missing SC.")
@@ -48,7 +48,7 @@ class TestSubcluster(unittest.TestCase):
         """
         Make sure that we have failures because SC CHANGEME section is present.
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/changeme_section_sc.ini")
         config_parser.read(config_file)
         self.assertRaises(exceptions.SettingError, subcluster.check_config, config_parser) # detect enabled CHANGEME section.
@@ -57,7 +57,7 @@ class TestSubcluster(unittest.TestCase):
         """
         Make sure that we can correctly parse a correct new-style GIP config.
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/red-new-gip-config.ini")
         config_parser.read(config_file)
         self.assertTrue(subcluster.check_config(config_parser))
@@ -66,7 +66,7 @@ class TestSubcluster(unittest.TestCase):
         """
         Test to see if the local settings parsing works.
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_parser.optionxform = str
         config_file = get_test_config("subcluster/local_settings.ini")
         config_parser.read(config_file)
@@ -96,7 +96,7 @@ class TestSubcluster(unittest.TestCase):
         Make sure a valid HEPSPEC value is accepted.
         """
         did_fail = False
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/sc_samples.ini")
         config_parser.read(config_file)
         try:
@@ -109,7 +109,7 @@ class TestSubcluster(unittest.TestCase):
         """
         Make sure a invalid HEPSPEC value no longer causes an error..
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/sc_samples.ini")
         config_parser.read(config_file)
         try:
@@ -125,7 +125,7 @@ class TestSubcluster(unittest.TestCase):
         """
         Make sure a Resource Entry section is detected
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/resourceentry.ini")
         config_parser.read(config_file)
         found_scs = subcluster.check_config(config_parser)
@@ -136,7 +136,7 @@ class TestSubcluster(unittest.TestCase):
         Make sure most subcluster attributes are optional for a
         Resource Entry section
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/resourceentry.ini")
         config_parser.read(config_file)
         did_fail = False
@@ -152,7 +152,7 @@ class TestSubcluster(unittest.TestCase):
         """
         Make sure a Pilot section is detected
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/pilot.ini")
         config_parser.read(config_file)
         found_scs = subcluster.check_config(config_parser)
@@ -162,7 +162,7 @@ class TestSubcluster(unittest.TestCase):
         """
         Make sure a Pilot section with no name is still OK
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/pilot_no_name.ini")
         config_parser.read(config_file)
         found_scs = subcluster.check_config(config_parser)
@@ -172,7 +172,7 @@ class TestSubcluster(unittest.TestCase):
         """
         Make sure that if "require_singularity=false", then "os" is required.
         """
-        config_parser = configparser.SafeConfigParser()
+        config_parser = configparser.ConfigParser()
         config_file = get_test_config("subcluster/pilot_no_singularity.ini")
         config_parser.read(config_file)
         self.assertRaises(exceptions.SettingError, subcluster.check_config, config_parser)  # Pilot w/ no singularity and no os should fail

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -117,7 +117,7 @@ class TestValidation(unittest.TestCase):
         Test functionality of valid_boolean function
         """
         config_file = get_test_config('utilities/valid_boolean.ini')
-        config = configparser.SafeConfigParser()
+        config = configparser.ConfigParser()
         config.read(config_file)
         self.assertFalse(validation.valid_boolean(config, 'Test', 'invalid_bool'),
                          'invalid_bool flagged as valid')


### PR DESCRIPTION
* platform.dist() got removed (but we don't need it anyway)
* ConfigParser.readfp() got replaced with ConfigParser.read_file()
* SafeConfigParser was removed in favor of just ConfigParser (although in get_option_location() we don't need interpolation so use RawConfigParser instead)